### PR TITLE
fix: update chatbot ai-studio.yaml and containerfile

### DIFF
--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -31,20 +31,22 @@ wget https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7
 
 ### Build the image
 
-To build the image we will use a `build.sh` script that will simply copy the desired model and shared code into the build directory temporarily. This prevents any large unused model files in the repo from being loaded into the podman environment during build which can cause a significant slowdown.    
+To build the image we will use a `build.sh` script that will simply build the image without any model. 
+After the image is created we could run it with the model mounted as volume. This prevents any large model file from being loaded into the podman environment during build which can cause a significant slowdown.
 
 ```bash
 cd chatbot/model_services/builds
 
-sh build.sh llama-2-7b-chat.Q5_K_S.gguf arm locallm
+sh build.sh locallm x86-cuda
 ```
-The user should provide the model name, the architecture and image name they want to use for the build. 
+The user should provide the image name and the architecture (no need to specify it without any specific hardware accelerator) they want to use for the build. 
 
 ### Run the image
 Once the model service image is built, it can be run with the following:
+By assuming that we want to mount the model `llama-2-7b-chat.Q5_K_S.gguf`
 
 ```bash
-podman run -it -p 7860:7860 locallm
+podman run -v <local-path>\llama-2-7b-chat.Q5_K_S.gguf:/llama-2-7b-chat.Q5_K_S.gguf:Z --env MODEL_PATH=/llama-2-7b-chat.Q5_K_S.gguf -it -p 7860:7860 locallm
 ```
 
 ### Interact with the app

--- a/chatbot/ai-studio.yaml
+++ b/chatbot/ai-studio.yaml
@@ -4,13 +4,15 @@ application:
   # description: This is a LLM chatbot application
   containers:
     - name: chatbot-example
-      contextdir: ai-application/builds
+      contextdir: ai-application
+      containerfile: builds/Containerfile
       #image-name: quay.io/redhat-et/chatbot:latest
-    - name: chatbot-model-arm
-      contextdir: model-services/builds/arm
-      arch: arm64
+    - name: chatbot-model
+      contextdir: model-services
+      containerfile: builds/Containerfile
       model-service: true 
-    - name: chatbot-model-x86
-      contextdir: model-services/builds/x86
-      arch: amd64
+    - name: chatbot-model-x86-cuda
+      contextdir: model-services
+      containerfile: builds/x86/Containerfile
+      arch: amd64-cuda
       model-service: true 

--- a/chatbot/model_services/builds/Containerfile
+++ b/chatbot/model_services/builds/Containerfile
@@ -3,8 +3,6 @@ WORKDIR /locallm
 COPY builds/requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
-ENV MODEL_PATH=builds/llama-2-7b-chat.Q5_K_S.gguf
-COPY ${MODEL_PATH} /locallm/models/
 COPY builds/src/ /locallm
 COPY chat_service.py /locallm/chat_service.py
 EXPOSE 7860

--- a/chatbot/model_services/builds/build.sh
+++ b/chatbot/model_services/builds/build.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/ bash
 
-MODEL=${1:-llama-2-7b-chat.Q5_K_S.gguf}
-ARCH=${2:-arm}
-IMAGE_NAME=${3:-locallm}
+IMAGE_NAME=${1:-locallm}
+ARCH=${2:-.}
 
-echo "building with $MODEL on $ARCH"
-cp ../../../models/$MODEL .
-cp -r ../../../src .
 podman build -t $IMAGE_NAME .. -f $ARCH/Containerfile
-rm $MODEL
-rm -rf src

--- a/chatbot/model_services/builds/src/llamacpp_utils.py
+++ b/chatbot/model_services/builds/src/llamacpp_utils.py
@@ -1,0 +1,31 @@
+from llama_cpp import Llama
+
+
+def tokenize(llama, prompt):
+    return llama.tokenize(bytes(prompt, "utf-8"))
+
+def count_tokens(llama,prompt):
+    return len(tokenize(llama,prompt)) + 5
+
+def clip_history(llama, prompt, history, n_ctx, max_tokens):
+    prompt_len = count_tokens(llama, prompt)
+    history_len = sum([count_tokens(llama, x["content"]) for x in history])
+    input_len = prompt_len + history_len
+    print(input_len)
+    while input_len >= n_ctx-max_tokens:
+        print("Clipping")
+        history.pop(1)
+        history_len = sum([count_tokens(llama, x["content"]) for x in history])
+        input_len = history_len + prompt_len
+        print(input_len)
+    return history
+
+def chunk_tokens(llm, prompt, chunk_size):
+    tokens = tokenize(llm, prompt)
+    num_tokens = count_tokens(llm, prompt)
+    chunks = []
+    for i in range((num_tokens//chunk_size)+1):
+        chunk = str(llm.detokenize(tokens[:chunk_size]),"utf-8")
+        chunks.append(chunk)
+        tokens = tokens[chunk_size:]
+    return chunks

--- a/chatbot/model_services/builds/x86-cuda/Containerfile
+++ b/chatbot/model_services/builds/x86-cuda/Containerfile
@@ -5,8 +5,6 @@ RUN pip install --upgrade pip
 ENV CMAKE_ARGS="-DLLAMA_CUBLAS=on"
 ENV FORCE_CMAKE=1
 RUN pip install --upgrade --force-reinstall --no-cache-dir -r /locallm/requirements.txt
-ENV MODEL_PATH=builds/llama-2-7b-chat.Q5_K_S.gguf
-COPY ${MODEL_FILE} /locallm/models/
 COPY builds/src/ /locallm
 COPY chat_service.py /locallm/chat_service.py
 ENTRYPOINT [ "python", "chat_service.py" ]


### PR DESCRIPTION
This PR updates the Chatbot app by adding/updating 4 things:

1) it makes the old arm containerfile the default one and makes the old x86 the containerfile for amd64-cuda hardware
2) it updates the ai-studio to represent the new structure and adds a new property `containerfile` so to know where it is within the folder and its actual name
3) it adds the `llamacpp_utils.py` inside the builds folder so that we do not need to run the `build.sh` script from podman-desktop after cloning the repo (this part can be removed if you prefer not to have duplicate files)
4) update the build.sh script and doc 