### PR TITLE
add playground build

### DIFF
--- a/playground/Containerfile
+++ b/playground/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/python-39:latest
+WORKDIR /locallm
+COPY requirements.txt /locallm/requirements.txt
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
+COPY run.sh run.sh
+ENTRYPOINT [ "sh", "run.sh" ]

--- a/playground/requirements.txt
+++ b/playground/requirements.txt
@@ -1,0 +1,1 @@
+llama-cpp-python[server]

--- a/playground/run.sh
+++ b/playground/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m llama_cpp.server --model ${MODEL_PATH} --host 0.0.0.0 --n_gpu_layers 0


### PR DESCRIPTION
Adds a a new directory "playground" that contains the `requirements.txt`,`run.sh` and `Containerfile` needed to build a simple llama.cpp compatible model server image. 

The image assumes that the model will be volume mounted at runtime, and so does not include any models. The image is only about ~1Gb. 
 