### PR TITLE
add quadlet.image for chatbot

### DIFF
--- a/chatbot/quadlet/chatbot.image
+++ b/chatbot/quadlet/chatbot.image
@@ -1,0 +1,7 @@
+[Install]
+WantedBy=chatbot.service
+
+[Image]
+Image=quay.io/sallyom/models:llama2-7b-gguf
+Image=quay.io/sallyom/chatbot:model-service
+Image=quay.io/sallyom/chatbot:inference

--- a/chatbot/quadlet/chatbot.kube.example
+++ b/chatbot/quadlet/chatbot.kube.example
@@ -7,7 +7,7 @@ RequiresMountsFor=%t/containers
 
 [Kube]
 # Point to the yaml file in the same directory
-Yaml=chatbot.yml
+Yaml=chatbot.yaml
 
 [Service]
 Restart=always


### PR DESCRIPTION
Adds an `.image` quadlet file to ensure application (chatbot) images are pulled on boot with bootc image
Example here: https://github.com/redhat-et/bootc-examples/blob/main/bootc-build/Containerfile 