### PR TITLE
add chatbot langchain recipe

### DIFF
--- a/chatbot-langchain/README.md
+++ b/chatbot-langchain/README.md
@@ -1,0 +1,15 @@
+# Streamlit + Langchain ChatBot Demo
+
+### Build image
+```bash
+cd chatbot-langchain
+podman build -t stchat . -f builds/Containerfile   
+```
+### Run image locally
+
+Make sure your model service is up and running before starting this container image. 
+
+
+```bash
+podman run -it -p 8501:8501 -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 stchat   
+```

--- a/chatbot-langchain/ai-studio.yaml
+++ b/chatbot-langchain/ai-studio.yaml
@@ -1,0 +1,20 @@
+application:
+  type: language
+  name: ChatBot_Streamlit
+  description: This is a Streamlit chat demo application. 
+  containers:
+    - name: llamacpp-server
+      contextdir: ../playground
+      containerfile: Containerfile
+      model-service: true
+      backend: 
+        - llama
+      arch:
+        - arm64
+        - amd64
+    - name: streamlit-chat-app
+      contextdir: .
+      containerfile: builds/Containerfile
+      arch:
+        - arm64
+        - amd64

--- a/chatbot-langchain/builds/Containerfile
+++ b/chatbot-langchain/builds/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9/python-39:latest
+WORKDIR /chat
+COPY builds/requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade -r /chat/requirements.txt
+COPY chatbot_ui.py .
+EXPOSE 8501
+ENTRYPOINT [ "streamlit", "run", "chatbot_ui.py" ]

--- a/chatbot-langchain/builds/requirements.txt
+++ b/chatbot-langchain/builds/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langchain_openai
+streamlit

--- a/chatbot-langchain/chatbot_ui.py
+++ b/chatbot-langchain/chatbot_ui.py
@@ -1,0 +1,39 @@
+from langchain_openai import ChatOpenAI
+from langchain.chains import LLMChain
+from langchain_community.callbacks import StreamlitCallbackHandler
+from langchain_core.prompts import ChatPromptTemplate
+import streamlit as st
+import os 
+
+
+model_service = os.getenv("MODEL_SERVICE_ENDPOINT",
+                          "http://localhost:8001/v1")
+
+st.title("💬 Chatbot")  
+if "messages" not in st.session_state:
+    st.session_state["messages"] = [{"role": "assistant", 
+                                     "content": "How can I help you?"}]
+
+for msg in st.session_state.messages:
+    st.chat_message(msg["role"]).write(msg["content"])
+
+llm = ChatOpenAI(base_url=model_service, 
+             api_key="sk-no-key-required",
+             streaming=True,
+             callbacks=[StreamlitCallbackHandler(st.container(),
+                                                expand_new_thoughts=True,
+                                                collapse_completed_thoughts=True)])
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are world class technical advisor."),
+    ("user", "{input}")
+])
+
+chain = LLMChain(llm=llm, prompt=prompt)
+
+if prompt := st.chat_input():
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    st.chat_message("user").markdown(prompt)
+    response = chain.invoke(prompt)
+    st.chat_message("assistant").markdown(response["text"])    
+    st.session_state.messages.append({"role": "assistant", "content": response["text"]})
+    st.rerun()


### PR DESCRIPTION
This is a new chatbot recipe that should eventually replace the current `chatbot/` recipe. 

This demo utilizes Streamlit for the UI and Langchain to interface more generically with a model service. It has currently been tested agains the "playground" image model service.  