### PR TITLE
add langchain summarizer application

### DIFF
--- a/summarizer-langchain/README.md
+++ b/summarizer-langchain/README.md
@@ -1,0 +1,16 @@
+# Summarizer Application
+
+This example will deploy a local summarization application.
+ 
+
+### Deploy Model Service
+
+To start the model service, refer to [the playground model-service document](../playground/README.md)
+
+### Build and Deploy Summarizer app
+
+
+Follow the instructions below to build you container image and run it locally. 
+
+* `podman build -t summarizer summarizer-langchain -f summarizer-langchain/builds/Containerfile`
+* `podman run --rm -it -p 8501:8501 -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 summarizer`

--- a/summarizer-langchain/ai-studio.yaml
+++ b/summarizer-langchain/ai-studio.yaml
@@ -1,0 +1,20 @@
+application:
+  type: language
+  name: Summarizer_App
+  description: This is a Streamlit demo application for summarizing text. 
+  containers:
+    - name: llamacpp-server
+      contextdir: ../playground
+      containerfile: Containerfile
+      model-service: true
+      backend: 
+        - llama
+      arch:
+        - arm64
+        - amd64
+    - name: streamlit-summary-app
+      contextdir: .
+      containerfile: builds/Containerfile
+      arch:
+        - arm64
+        - amd64

--- a/summarizer-langchain/builds/Containerfile
+++ b/summarizer-langchain/builds/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9/python-39:latest
+WORKDIR /summarizer
+COPY builds/requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade -r /summarizer/requirements.txt
+COPY summarizer.py .
+EXPOSE 8501
+ENTRYPOINT [ "streamlit", "run", "summarizer.py" ]

--- a/summarizer-langchain/builds/requirements.txt
+++ b/summarizer-langchain/builds/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langchain_openai
+streamlit

--- a/summarizer-langchain/summarizer.py
+++ b/summarizer-langchain/summarizer.py
@@ -1,0 +1,65 @@
+
+from langchain_openai import ChatOpenAI
+from langchain.prompts import PromptTemplate
+from langchain_community.callbacks import StreamlitCallbackHandler
+import streamlit as st
+import os
+
+model_service = os.getenv("MODEL_SERVICE_ENDPOINT",
+                          "http://localhost:8001/v1")
+
+estimation_factor = 1.50
+chunk_size = int(2048//estimation_factor)
+
+def estimate_tokens(prompt):
+    return int(len(prompt.split()) * estimation_factor)
+
+def chunk_text(prompt):
+    chunks = []
+    num_tokens = estimate_tokens(prompt)
+    for _ in range((num_tokens//chunk_size)+1):
+        chunk = prompt[:chunk_size]
+        chunks.append(chunk)
+    return chunks
+
+st.title("🔎 Summarizer")
+file = st.file_uploader("Upload file")
+
+llm = ChatOpenAI(base_url=model_service,
+             api_key="not required",
+             streaming=True,
+             max_tokens=200,
+             )
+
+### prompt example is from  https://python.langchain.com/docs/use_cases/summarization
+refine_template = PromptTemplate.from_template(
+    "Your job is to produce a final summary\n"
+    "We have provided an existing summary up to a certain point: {existing_answer}\n"
+    "We have the opportunity to refine the existing summary"
+    "(only if needed) with some more context below.\n"
+    "------------\n"
+    "{text}\n"
+    "------------\n"
+    "Given the new context, refine the original summary"
+    "If the context isn't useful, return the original summary."
+    "Only use bullet points."
+    "Dont ever go beyond 10 bullet points."
+)
+                        
+if file != None:    
+    text = file.read().decode()    
+    chunks = chunk_text(text)
+    num_chunks = len(chunks)
+    st.write(f"Processing data in {num_chunks} chunks...")
+    progbar = st.progress(0.01, text="")
+    existing_answer = ""
+    for i, chunk in enumerate(chunks):
+        progbar.progress((i+1)/(num_chunks), text="")
+        if i+1 < num_chunks:
+            response = llm.invoke(refine_template.format(text=chunk,existing_answer=existing_answer))
+            existing_answer = response.content
+        else:
+            with st.spinner("Preparing Aggregated Summary"):
+                response = llm.stream(refine_template.format(text=chunk,existing_answer=existing_answer))
+                st.write_stream(response)
+        


### PR DESCRIPTION
This is a new summarization recipe that should eventually replace the current `summarization/` recipe.

This demo utilizes Streamlit for the UI and Langchain to interface more generically with a model service. It has currently been tested against the "playground" image model service.

<img width="1057" alt="Screenshot 2024-02-09 at 4 38 45 PM" src="https://github.com/redhat-et/locallm/assets/4494906/21330b86-fb06-4e35-a27b-05eeb132ace6">
