### PR TITLE
feat: add ports to ai-studio

### DIFF
--- a/chatbot-langchain/ai-studio.yaml
+++ b/chatbot-langchain/ai-studio.yaml
@@ -12,9 +12,13 @@ application:
       arch:
         - arm64
         - amd64
+      ports:
+        - 8001
     - name: streamlit-chat-app
       contextdir: .
       containerfile: builds/Containerfile
       arch:
         - arm64
         - amd64
+      ports:
+        - 8501

--- a/code-generation/ai-studio.yaml
+++ b/code-generation/ai-studio.yaml
@@ -12,9 +12,13 @@ application:
       arch:
         - arm64
         - amd64
+      ports:
+        - 8001
     - name: codegen-app
       contextdir: .
       containerfile: builds/Containerfile
       arch:
         - arm64
         - amd64
+      ports:
+        - 8501

--- a/rag-langchain/ai-studio.yaml
+++ b/rag-langchain/ai-studio.yaml
@@ -12,6 +12,8 @@ application:
       arch:
         - arm64
         - amd64
+      ports:
+        - 8001
     - name: chromadb-server
       contextdir:: builds/chromadb
       containerfile: Containerfile
@@ -19,9 +21,13 @@ application:
       arch:
         - arm64
         - amd64
+      ports:
+        - 8000
     - name: rag-inference-app
       contextdir: .
       containerfile: builds/Containerfile
       arch:
         - arm64
         - amd64
+      ports:
+        - 8501

--- a/summarizer-langchain/ai-studio.yaml
+++ b/summarizer-langchain/ai-studio.yaml
@@ -12,9 +12,13 @@ application:
       arch:
         - arm64
         - amd64
+      ports:
+        - 8001
     - name: streamlit-summary-app
       contextdir: .
       containerfile: builds/Containerfile
       arch:
         - arm64
         - amd64
+      ports:
+        - 8501


### PR DESCRIPTION
This PR adds a new property `Ports` in the ai-studio.yaml files.
This includes the ports used by the every single element within an ai application (model_service, vectordb, ai app).

It will be used by ai-studio to know which port to use when opening an app in the browser or which ports to set in the pod (also if we split the model_services and the ai app in different pods in future).

This is needed bc we now retrieve the ports info from the images exposedPorts property but this can contain ports related to the base image which is something we do not need to handle. E.g. by using the  `registry.access.redhat.com/ubi9/python-39:latest` base image the port 8080 is also exposed.