### PR TITLE
chore: add version to ai-studio.yaml

### DIFF
--- a/chatbot-langchain/ai-studio.yaml
+++ b/chatbot-langchain/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: ChatBot_Streamlit

--- a/chatbot/ai-studio.yaml
+++ b/chatbot/ai-studio.yaml
@@ -1,3 +1,5 @@
+
+version: v1.0
 application:
   type: language
   name: chatbot

--- a/code-generation/ai-studio.yaml
+++ b/code-generation/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: codegen-demo

--- a/rag-langchain/ai-studio.yaml
+++ b/rag-langchain/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: rag-demo

--- a/rag/ai-studio.yaml
+++ b/rag/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: rag-demo

--- a/summarizer-langchain/ai-studio.yaml
+++ b/summarizer-langchain/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: Summarizer_App

--- a/summarizer/ai-studio.yaml
+++ b/summarizer/ai-studio.yaml
@@ -1,3 +1,4 @@
+version: v1.0
 application:
   type: language
   name: summarizer


### PR DESCRIPTION
This PR adds a version tag to all ai-studio.yaml files.

From a desktop perspective, we could use the version to handle different ai-studio schemas in future release in case of some breaking changes.