### PR TITLE
Add option for config file in playground

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -68,5 +68,5 @@ podman run --rm -it -d \
         -p 8001:8001 \
         -v Local/path/to/locallm/models:/locallm/models:ro,Z \
         -e CONFIG_PATH=models/<config-filename> \
-        playground:image`
+        playground:image
 ```

--- a/playground/README.md
+++ b/playground/README.md
@@ -23,7 +23,9 @@ cd ../
 
 ### Deploy Model Service
 
-Deploy the LLM server and volume mount the model of choice.
+#### Single Model Service:
+
+Deploy the LLM server and volume mount the model of choice using the `MODEL_PATH` environment variable.
 
 ```bash
 podman run --rm -it -d \
@@ -32,5 +34,39 @@ podman run --rm -it -d \
         -e MODEL_PATH=models/<model-filename> \
         -e HOST=0.0.0.0 \
         -e PORT=8001 \
+        playground:image`
+```
+
+#### Multiple Model Service:
+
+To enable dynamic loading and unloading of different models present on your machine, you can start the model service with a `CONFIG_PATH` instead of a `MODEL_PATH`.
+
+Here is an example `models_config.json` with two quantization variants of mistral-7B.
+```json
+{
+    "host": "0.0.0.0",
+    "port": 8001,
+    "models": [
+        {
+            "model": "models/mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+            "model_alias": "mistral_Q4",
+            "chat_format": "mistral",
+        },
+        {
+            "model": "models/mistral-7b-instruct-v0.1.Q5_K_M.gguf",
+            "model_alias": "mistral_Q5",
+            "chat_format": "mistral",
+        },
+
+    ]
+}
+```
+
+Now run the container with the specified config file. 
+```bash
+podman run --rm -it -d \
+        -p 8001:8001 \
+        -v Local/path/to/locallm/models:/locallm/models:ro,Z \
+        -e CONFIG_PATH=models/<config-filename> \
         playground:image`
 ```

--- a/playground/run.sh
+++ b/playground/run.sh
@@ -1,2 +1,14 @@
 #!/bin/bash
-python -m llama_cpp.server --model ${MODEL_PATH} --host ${HOST:=0.0.0.0} --port ${PORT:=8001} --n_gpu_layers ${GPU_LAYERS:=0} --clip_model_path ${CLIP_MODEL_PATH:=None} --chat_format ${CHAT_FORMAT:="llama-2"}
+if [ ${CONFIG_PATH} ] || [[ ${MODEL_PATH} && ${CONFIG_PATH} ]]; then
+    python -m llama_cpp.server --config_file ${CONFIG_PATH}
+    exit 0
+fi
+
+if [ ${MODEL_PATH} ]; then
+    python -m llama_cpp.server --model ${MODEL_PATH} --host ${HOST:=0.0.0.0} --port ${PORT:=8001} --n_gpu_layers ${GPU_LAYERS:=0} --clip_model_path ${CLIP_MODEL_PATH:=None} --chat_format ${CHAT_FORMAT:="llama-2"}
+    exit 0
+fi
+
+echo "Please set either a CONFIG_PATH or a MODEL_PATH"
+exit 1
+


### PR DESCRIPTION
This PR updates the playground's `run.sh` to allow for the use of config files. Which, in tern allows for the server to load and unload multiple models without restarting the service.  

This feature was requested by a couple members of the AI-studio team. Please consider this PR as a way to test and evaluate if we want to move forward with this approach to loading models in the playground.  