### PR TITLE
chore: add image field to define image name when building

### DIFF
--- a/chatbot-langchain/ai-studio.yaml
+++ b/chatbot-langchain/ai-studio.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8001
-      image: quay.io/redhat-et/llamacpp-server
+      image: quay.io/redhat-et/locallm-model-service:latest
     - name: streamlit-chat-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -24,4 +24,4 @@ application:
         - amd64
       ports:
         - 8501
-      image: quay.io/redhat-et/streamlit-chat-app
+      image: quay.io/redhat-et/locallm-chatbot:latest

--- a/chatbot-langchain/ai-studio.yaml
+++ b/chatbot-langchain/ai-studio.yaml
@@ -15,6 +15,7 @@ application:
         - amd64
       ports:
         - 8001
+      image: quay.io/redhat-et/llamacpp-server
     - name: streamlit-chat-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -23,3 +24,4 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/streamlit-chat-app

--- a/code-generation/ai-studio.yaml
+++ b/code-generation/ai-studio.yaml
@@ -15,6 +15,7 @@ application:
         - amd64
       ports:
         - 8001
+      image: quay.io/redhat-et/llamacpp-server
     - name: codegen-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -23,3 +24,4 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/codegen-app

--- a/code-generation/ai-studio.yaml
+++ b/code-generation/ai-studio.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8001
-      image: quay.io/redhat-et/llamacpp-server
+      image: quay.io/redhat-et/locallm-model-service:latest
     - name: codegen-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -24,4 +24,4 @@ application:
         - amd64
       ports:
         - 8501
-      image: quay.io/redhat-et/codegen-app
+      image: quay.io/redhat-et/locallm-codegen:latest

--- a/object_detection/ai-studio.yaml
+++ b/object_detection/ai-studio.yaml
@@ -15,6 +15,7 @@ application:
         - amd64
       ports:
         - 8000
+      image: quay.io/redhat-et/object-detection-server
     - name: object-detection-client
       contextdir: ./client
       containerfile: Containerfile
@@ -23,3 +24,4 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/object-detection-client

--- a/rag-langchain/ai-studio.yaml
+++ b/rag-langchain/ai-studio.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8001
-      image: quay.io/redhat-et/llamacpp-server
+      image: quay.io/redhat-et/locallm-model-service:latest
     - name: chromadb-server
       contextdir: builds/chromadb
       containerfile: Containerfile
@@ -25,7 +25,7 @@ application:
         - amd64
       ports:
         - 8000
-      image: quay.io/redhat-et/chromadb-server
+      image: quay.io/redhat-et/locallm-chromadb:latest
     - name: rag-inference-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -34,4 +34,4 @@ application:
         - amd64
       ports:
         - 8501
-      image: quay.io/redhat-et/rag-inference-app
+      image: quay.io/redhat-et/locallm-rag:latest

--- a/rag-langchain/ai-studio.yaml
+++ b/rag-langchain/ai-studio.yaml
@@ -15,6 +15,7 @@ application:
         - amd64
       ports:
         - 8001
+      image: quay.io/redhat-et/llamacpp-server
     - name: chromadb-server
       contextdir: builds/chromadb
       containerfile: Containerfile
@@ -24,6 +25,7 @@ application:
         - amd64
       ports:
         - 8000
+      image: quay.io/redhat-et/chromadb-server
     - name: rag-inference-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -32,3 +34,4 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/rag-inference-app

--- a/summarizer-langchain/ai-studio.yaml
+++ b/summarizer-langchain/ai-studio.yaml
@@ -15,6 +15,7 @@ application:
         - amd64
       ports:
         - 8001
+      image: quay.io/redhat-et/llamacpp-server
     - name: streamlit-summary-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -23,3 +24,4 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/streamlit-summary-app

--- a/summarizer-langchain/ai-studio.yaml
+++ b/summarizer-langchain/ai-studio.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8001
-      image: quay.io/redhat-et/llamacpp-server
+      image: quay.io/redhat-et/locallm-model-service:latest
     - name: streamlit-summary-app
       contextdir: .
       containerfile: builds/Containerfile
@@ -24,4 +24,4 @@ application:
         - amd64
       ports:
         - 8501
-      image: quay.io/redhat-et/streamlit-summary-app
+      image: quay.io/redhat-et/locallm-text-summarizer:latest


### PR DESCRIPTION
This PR adds a new field `image` which defines the name to be used when building the container image.

This is related to https://github.com/projectatomic/ai-studio/issues/161 

@sallyom as we do not have much time to make additional customization let us know if those names are good for you as default values for the demo or you would prefer something else. Thank you!!