### PR TITLE
image updates

### DIFF
--- a/chatbot-langchain/quadlet/chatbot.image
+++ b/chatbot-langchain/quadlet/chatbot.image
@@ -2,6 +2,6 @@
 WantedBy=chatbot.service
 
 [Image]
-Image=quay.io/redhat-et/locallm-models:mistral-7b-instruct-v0.1.Q4_K_S.gguf
+Image=quay.io/redhat-et/locallm-mistral-7b-gguf:latest
 Image=quay.io/redhat-et/locallm-model-service:latest
 Image=quay.io/redhat-et/locallm-chatbot:latest

--- a/chatbot-langchain/quadlet/chatbot.yaml
+++ b/chatbot-langchain/quadlet/chatbot.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
   - name: model-file
-    image: quay.io/redhat-et/locallm-models:mistral-7b-instruct-v0.1.Q4_K_S.gguf
+    image: quay.io/redhat-et/locallm-mistral-7b-gguf:latest
     command: ['/usr/bin/install', "/model/mistral-7b-instruct-v0.1.Q4_K_S.gguf", "/shared/"]
     volumeMounts:
     - name: model-file

--- a/code-generation/quadlet/codegen.image
+++ b/code-generation/quadlet/codegen.image
@@ -2,6 +2,6 @@
 WantedBy=codegen.service
 
 [Image]
-Image=quay.io/redhat-et/locallm-models:codellama-7b-instruct.Q4_K_M.gguf
+Image=quay.io/redhat-et/locallm-codellama-7b-gguf:latest
 Image=quay.io/redhat-et/locallm-model-service:latest
 Image=quay.io/redhat-et/locallm-codegen:latest

--- a/code-generation/quadlet/codegen.yaml
+++ b/code-generation/quadlet/codegen.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
   - name: model-file
-    image: quay.io/redhat-et/locallm-models:codellama-7b-instruct.Q4_K_M.gguf
+    image: quay.io/redhat-et/locallm-codellama-7b-gguf:latest
     command: ['/usr/bin/install', "/model/codellama-7b-instruct.Q4_K_M.gguf", "/shared/"]
     volumeMounts:
     - name: model-file

--- a/locallm-images.md
+++ b/locallm-images.md
@@ -1,4 +1,4 @@
-## Images currently built from GH Actions in this repository
+## Images (x86_64, aarch64) currently built from GH Actions in this repository
 
 - quay.io/redhat-et/locallm-model-service:latest
 - quay.io/redhat-et/locallm-text-summarizer:latest
@@ -6,12 +6,14 @@
 - quay.io/redhat-et/locallm-rag:latest
 - quay.io/redhat-et/locallm-codegen:latest
 - quay.io/redhat-et/locallm-chromadb:latest
+- quay.io/redhat-et/locallm-object-detection-client:latest
+- quay.io/redhat-et/locallm-object-detection-server:latest
 
-## Model Images currently in `quay.io/redhat-et/locallm-models`
+## Model Images (x86_64, aarch64) currently in `quay.io/redhat-et/locallm-*`
 
-- quay.io/redhat-et/locallm-models:llama-2-7b-chat.Q5_K_S.gguf
+- quay.io/redhat-et/locallm-llama-2-7b:latest
     - [model download link](https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q5_K_S.gguf)
-- quay.io/redhat-et/locallm-models:mistral-7b-instruct-v0.1.Q4_K_S.gguf
+- quay.io/redhat-et/locallm-mistral-7b-gguf:latest
     - [model download link](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_S.gguf)
-- quay.io/redhat-et/locallm-models:codellama-7b-instruct.Q4_K_M.gguf
+- quay.io/redhat-et/locallm-codellama-7b-gguf:latest
     - [model download link](https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf) 

--- a/object_detection/ai-studio.yaml
+++ b/object_detection/ai-studio.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8000
-      image: quay.io/redhat-et/object-detection-server
+      image: quay.io/redhat-et/locallm-object-detection-server:latest
     - name: object-detection-client
       contextdir: ./client
       containerfile: Containerfile
@@ -24,4 +24,4 @@ application:
         - amd64
       ports:
         - 8501
-      image: quay.io/redhat-et/object-detection-client
+      image: quay.io/redhat-et/locallm-object-detection-client:latest

--- a/summarizer-langchain/quadlet/summarizer.image
+++ b/summarizer-langchain/quadlet/summarizer.image
@@ -2,6 +2,6 @@
 WantedBy=summarizer.service
 
 [Image]
-Image=quay.io/redhat-et/locallm-models:mistral-7b-instruct-v0.1.Q4_K_S.gguf
+Image=quay.io/redhat-et/locallm-mistral-7b-gguf:latest
 Image=quay.io/redhat-et/locallm-model-service:latest
 Image=quay.io/redhat-et/locallm-text-summarizer:latest

--- a/summarizer-langchain/quadlet/summarizer.yaml
+++ b/summarizer-langchain/quadlet/summarizer.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
   - name: model-file
-    image: quay.io/redhat-et/locallm-models:mistral-7b-instruct-v0.1.Q4_K_S.gguf
+    image: quay.io/redhat-et/locallm-mistral-7b-gguf:latest
     command: ['/usr/bin/install', "/model/mistral-7b-instruct-v0.1.Q4_K_S.gguf", "/shared/"]
     volumeMounts:
     - name: model-file


### PR DESCRIPTION
updating image refs to what is currently in `quay.io/redhat-et` 
@MichaelClifford ptal, thanks! 
@lstocchi for now, images are all named `quay.io/redhat-et/locallm-*` only because that's what we started with. We can decide on better names & update later. 