### PR TITLE
Provisioning with user_data

### DIFF
--- a/.github/scripts/provision.sh
+++ b/.github/scripts/provision.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+
+dnf install -y podman wget
+dnf clean all
+
+wget -P locallm/models https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q5_K_S.gguf
+podman run -it -d \
+        -p 8001:8001 \
+        -v ./locallm/models:/locallm/models:ro,Z \
+        -e MODEL_PATH=models/llama-2-7b-chat.Q5_K_S.gguf \
+        -e HOST=0.0.0.0 \
+        -e PORT=8001 \
+        ghcr.io/containers/model_servers:latest
+podman run -it \
+        -p 8501:8501 \
+        -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 \
+        ghcr.io/containers/chatbot:latest

--- a/.github/workflows/testing-framework.yaml
+++ b/.github/workflows/testing-framework.yaml
@@ -18,6 +18,14 @@ env:
   TF_VAR_aws_volume_size: 100
   TF_VAR_aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
   TF_VAR_aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  TF_VAR_provision_script: ./main/.github/scripts/provision.sh
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: "eu-west-2"
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   spin-test-environment:
@@ -46,12 +54,18 @@ jobs:
         working-directory: terraform-test-environment-module
 
       - name: Spin Test Environment
-        id: apply
+        id: up
         run: terraform apply -auto-approve -lock=false
         working-directory: terraform-test-environment-module
       
+      - id: id
+        run: echo "id=$(terraform output id | xargs)" >> $GITHUB_OUTPUT
+        working-directory: terraform-test-environment-module
+      
+      - run: aws ec2 wait instance-status-ok --instance-ids ${{ steps.id.outputs.id }}
+
       - name: Destroy Test Environment
-        id: destroy
+        id: down
         if: always()
         run: terraform destroy -auto-approve -lock=false
         working-directory: terraform-test-environment-module


### PR DESCRIPTION
provision.sh script is used to provision the instance that the terraform is spinning in the up step.  The script is consumed by the terraform configuration as the instance user_data.
the `aws ec2 wait` command is used for waiting until the provision.sh script is completed.
The destroy step which is invoked even if previous steps failed, is destroying the resources generated by the terraform configuration.