### PR TITLE
add support for make bootc FROM=

### DIFF
--- a/recipes/natural_language_processing/chatbot/Makefile
+++ b/recipes/natural_language_processing/chatbot/Makefile
@@ -4,6 +4,7 @@ APPIMAGE ?= quay.io/ai-lab/${APP}:latest
 SERVERIMAGE ?= quay.io/ai-lab/llamacpp-python:latest
 SSHPUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
 BOOTCIMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
+FROM ?=
 
 .PHONY: build
 build:
@@ -11,7 +12,7 @@ build:
 
 .PHONY: bootc
 bootc: quadlet
-	podman build --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
+	podman build $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
 
 .PHONY: quadlet
 quadlet:

--- a/recipes/natural_language_processing/chatbot/README.md
+++ b/recipes/natural_language_processing/chatbot/README.md
@@ -130,14 +130,20 @@ and run:
 
 
 ```
-make BOOTCIMAGE=quay.io/your/bootc-chatbot:latest bootc
+make BOOTCIMAGE=quay.io/your/chatbot-bootc:latest bootc
+```
+
+Substituting the bootc/Containerfile FROM command is simple using the Makefile FROM option.
+
+```
+make FROM=registry.redhat.io/rhel9-beta/rhel-bootc:9.4 BOOTCIMAGE=quay.io/your/chatbot-bootc:latest bootc
 ```
 
 The magic happens when you have a bootc enabled system running. If you do, and you'd like to update the operating system to the OS you just built
 with the chatbot application, it's as simple as ssh-ing into the bootc system and running:
 
 ```
-bootc switch quay.io/your/bootc-chatbot:latest
+bootc switch quay.io/your/chatbot-bootc:latest
 ```
 
 Upon a reboot, you'll see that the chatbot service is running on the system.

--- a/recipes/natural_language_processing/rag/Makefile
+++ b/recipes/natural_language_processing/rag/Makefile
@@ -5,6 +5,7 @@ APPIMAGE ?= quay.io/ai-lab/${APP}:latest
 SERVERIMAGE ?= quay.io/ai-lab/llamacpp-python:latest
 SSHPUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
 BOOTCIMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
+FROM ?=
 
 .PHONY: build
 build:
@@ -12,7 +13,7 @@ build:
 
 .PHONY: bootc
 bootc: quadlet
-	podman build --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
+	podman build $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
 
 .PHONY: quadlet
 quadlet:

--- a/recipes/natural_language_processing/rag/README.md
+++ b/recipes/natural_language_processing/rag/README.md
@@ -158,14 +158,20 @@ and run:
 
 
 ```
-make BOOTCIMAGE=quay.io/your/bootc-rag-chatbot:latest bootc
+make BOOTCIMAGE=quay.io/your/rag-bootc:latest bootc
+```
+
+Substituting the bootc/Containerfile FROM command is simple using the Makefile FROM option.
+
+```
+make FROM=registry.redhat.io/rhel9-beta/rhel-bootc:9.4 BOOTCIMAGE=quay.io/your/rag-bootc:latest bootc
 ```
 
 The magic happens when you have a bootc enabled system running. If you do, and you'd like to update the operating system to the OS you just built
 with the RAG chatbot application, it's as simple as ssh-ing into the bootc system and running:
 
 ```
-bootc switch quay.io/your/bootc-rag-chatbot:latest
+bootc switch quay.io/your/rag-bootc:latest
 ```
 
 Upon a reboot, you'll see that the RAG chatbot service is running on the system.

--- a/recipes/natural_language_processing/summarizer/Makefile
+++ b/recipes/natural_language_processing/summarizer/Makefile
@@ -4,6 +4,7 @@ APPIMAGE ?= quay.io/ai-lab/${APP}:latest
 SERVERIMAGE ?= quay.io/ai-lab/llamacpp-python:latest
 SSHPUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
 BOOTCIMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
+FROM ?=
 
 .PHONY: build
 build:
@@ -11,7 +12,7 @@ build:
 
 .PHONY: bootc
 bootc: quadlet
-	podman build --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
+	podman build $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
 
 .PHONY: quadlet
 quadlet:

--- a/recipes/natural_language_processing/summarizer/README.md
+++ b/recipes/natural_language_processing/summarizer/README.md
@@ -126,14 +126,23 @@ To build a bootable container image that includes this sample summarizer workloa
 and run:
 
 ```
-make BOOTCIMAGE=quay.io/your/bootc-summarizer:latest bootc
+make BOOTCIMAGE=quay.io/your/summarizer-bootc:latest bootc
+```
+
+You can easily swap out the bootc/Containerfile FROM option with the following make command:
+```
+
+Substituting the bootc/Containerfile FROM command is simple using the Makefile FROM option.
+
+```
+make FROM=registry.redhat.io/rhel9-beta/rhel-bootc:9.4 BOOTCIMAGE=quay.io/your/summarizer-bootc:latest bootc
 ```
 
 The magic happens when you have a bootc enabled system running. If you do, and you'd like to update the operating system to the OS you just built
 with the summarizer application, it's as simple as ssh-ing into the bootc system and running:
 
 ```
-bootc switch quay.io/your/bootc-summarizer:latest
+bootc switch quay.io/your/summarizer-bootc:latest
 ```
 
 Upon a reboot, you'll see that the summarizer service is running on the system.


### PR DESCRIPTION
With this change users can do something like

make bootc FROM="--from registry.redhat.io/rhel9-beta/rhel-bootc:9.4"

And change the default image in the bootc container from Centos to RHEL.