### PR TITLE
update whipser ms scripts and docs

### DIFF
--- a/.github/workflows/model_servers.yaml
+++ b/.github/workflows/model_servers.yaml
@@ -4,19 +4,25 @@ on:
   pull_request:
     branches:
       - main
-    # paths:
-    #   - ./model_servers/llamacpp_python/**
-    #   - .github/workflows/model_servers.yaml
+    paths:
+      - ./model_servers/
+      - .github/workflows/model_servers.yaml
   push:
     branches:
       - main
-    # paths:
-    #   - ./model_servers/llamacpp_python/**
-    #   - .github/workflows/model_servers.yaml
+    paths:
+      - ./model_servers/
+      - .github/workflows/model_servers.yaml
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/model_servers
+  # Image Repo Migration variables
+  NEW_REGISTRY: quay.io 
+  NEW_REGISTRY_USER: ai-lab+ghrobot
+  NEW_IMAGE_NAME_LLAMA:  quay.io/ai-lab/model_servers/llamacpp_python
+  IMAGE_NAME_WHISPER: quay.io/ai-lab/model_servers/whispercpp
+
 
 jobs:
   build-and-push-image:
@@ -78,3 +84,47 @@ jobs:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
           registry: ${{ env.REGISTRY }}
+  build-and-push-image-whispercpp:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    services:
+      registry:
+        image: registry:2.8.3
+        ports:
+          - 5000:5000
+    steps:
+      - name: Build Image Whispercpp
+        id: build_image_whisper
+        uses: redhat-actions/buildah-build@v2.13
+        working-directory: ./model_servers/whispercpp/
+        run: make build
+
+      - name: Download model Whispercpp
+        working-directory: ./model_servers/whispercpp/
+        run: make download-model-whisper-small
+
+      - name: Login to container registry
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ${{ env.NEW_REGISTRY }}
+          username: ${{ env.NEW_REGISTRY_USER }}
+          password: ${{ secrets.AILAB_GHROBOT_TOKEN }} # THIS NEEDS TO BE CREATED
+
+      - name: Push image
+        id: push_image
+        if: >
+          (github.event_name == 'push' || github.event_name == 'schedule') &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+          
+        uses: redhat-actions/push-to-registry@v2.8
+        with:
+          image: ${{ steps.build_image_whisper.outputs.image }}
+          tags: ${{ steps.build_image_whisper.outputs.tags }}
+          registry: ${{ env.NEW_REGISTRY }}
+

--- a/model_servers/whispercpp/Makefile
+++ b/model_servers/whispercpp/Makefile
@@ -1,0 +1,47 @@
+PORT := 8001
+APP := whispercpp
+IMAGE := quay.io/ai-lab/model_servers/$(APP):latest
+CUDA_IMAGE := quay.io/ai-lab/model_servers/$(APP)_cuda:latest
+VULKAN_IMAGE :=quay.io/ai-lab/model_servers/$(APP)_vulkan:latest
+
+# ----- MODEL OPTIONS -----
+
+WHISPER_SMALL_MODEL_NAME := ggml-small.bin
+WHISPER_SMALL_MODEL_URL := https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+
+WHISPER_BASE_MODEL_NAME := ggml-base.en.bin
+WHISPER_BASE_MODEL_URL := https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+
+SELECTED_MODEL_NAME := $(or $(SELECTED_MODEL),$(WHISPER_SMALL_MODEL_NAME))
+
+# --- END MODEL OPTIONS ---
+
+MODELS_PATH := /app/models
+
+BIND_MOUNT_OPTIONS :=  ro
+OS := $(shell uname -s)
+ifeq ($(OS),Linux)
+    BIND_MOUNT_OPTIONS := Z,ro
+endif
+
+.PHONY: all
+all: build download-model-whisper-small run
+
+.PHONY: build
+build:
+	podman build -t $(IMAGE) . -f Containerfile
+
+.PHONY: download-model-whisper-small
+download-model-whisper-small: 
+	cd ../../models && \
+	curl -s -S -L -f $(WHISPER_SMALL_MODEL_URL) -z $(WHISPER_SMALL_MODEL_NAME) -o $(WHISPER_SMALL_MODEL_NAME).tmp && mv -f $(WHISPER_SMALL_MODEL_NAME).tmp $(WHISPER_SMALL_MODEL_NAME) 2>/dev/null || rm -f $(WHISPER_SMALL_MODEL_NAME).tmp $(WHISPER_SMALL_MODEL_NAME)
+
+.PHONY: download-model-whisper-base
+download-model-whisper-base: 
+	cd ../../models && \
+	curl -s -S -L -f $(WHISPER_BASE_MODEL_URL) -z $(WHISPER_BASE_MODEL_NAME) -o $(WHISPER_BASE_MODEL_NAME).tmp && mv -f $(WHISPER_BASE_MODEL_NAME).tmp $(WHISPER_BASE_MODEL_NAME) 2>/dev/null || rm -f $(WHISPER_BASE_MODEL_NAME).tmp $(WHISPER_BASE_MODEL_NAME)
+
+.PHONY: run
+run:
+	cd ../../models && \
+	podman run -d --rm -it -p $(PORT):$(PORT) -v ./$(SELECTED_MODEL_NAME):$(MODELS_PATH)/$(SELECTED_MODEL_NAME):$(BIND_MOUNT_OPTIONS) -e HOST=0.0.0.0 -e MODEL_PATH=$(MODELS_PATH)/$(SELECTED_MODEL_NAME) -e PORT=$(PORT) $(IMAGE)

--- a/model_servers/whispercpp/README.md
+++ b/model_servers/whispercpp/README.md
@@ -10,6 +10,11 @@ To build a Whisper model service container image from this directory,
 ```bash
 podman build -t whisper:image .
 ```
+or
+
+```bash
+make -f Makefile build 
+```
 
 ### Download Whisper model
 
@@ -19,10 +24,13 @@ You can to download the model from HuggingFace. There are various Whisper models
 - **small**
     - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin)
 
+- **base.en**
+    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin)
+
 ```bash
-cd ../models
-wget --no-config --quiet --show-progress -O ggml-small.bin <Download URL>
-cd ../
+cd ../../models
+curl -sLO <Download URL>
+cd ../model_servers/whispercpp
 ```
 
 ### Deploy Model Service
@@ -41,6 +49,10 @@ podman run --rm -it \
         -e PORT=8001 \
         whisper:image
 ```
+
+or using the make command:
+
+`make -f Makefile run`
 
 By default, a sample `jfk.wav` file is included in the whisper image. This can be used to test with.
 The environment variable `AUDIO_FILE`, can be passed with your own audio file to override the default `/app/jfk.wav` file within the whisper image.

--- a/model_servers/whispercpp/src/run.sh
+++ b/model_servers/whispercpp/src/run.sh
@@ -1,4 +1,3 @@
-#! bin/bash
+#!/bin/bash
 
 ./server -tr --model ${MODEL_PATH} --host ${HOST:=0.0.0.0} --port ${PORT:=8001}
-


### PR DESCRIPTION
/cc @rhatdan, whats our plan for converting the image repos (`ghcr.io` --> `quay.io`) with regard to the Github secrets in this repo? I cannot make these changes myself as I dont have permsions to access settings on this repo. Could I ask you take care of that for me or give me access?

changes:
- introduce a new github workflow for the whisper ms
- introduce a makefile for whisper builds
- update docs to use these new commands