### PR TITLE
Ollama ms docs and chatbot recipe udpates

### DIFF
--- a/.github/workflows/chatbot.yaml
+++ b/.github/workflows/chatbot.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run Functional Tests
         working-directory: ./recipes/natural_language_processing/chatbot
-        run: make functional_tests
+        run: make functional-tests
 
       - name: Login to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/testing-framework.yaml
+++ b/.github/workflows/testing-framework.yaml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Run Integration Tests
         working-directory: ./main/recipes/natural_language_processing/chatbot
-        run: make URL=${{ steps.terraform-output.outputs.url }} integration_tests
+        run: make integration-tests
+        env:
+          URL: ${{ steps.terraform-output.outputs.url }}
  
       - name: Destroy Test Environment
         id: down

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ model_servers/llamacpp_python/model.gguf
 !models/convert_models/*
 !models/Containerfile
 !models/README.md
+recipes/chromedriver

--- a/model_servers/ollama/README.md
+++ b/model_servers/ollama/README.md
@@ -14,7 +14,8 @@ ollama pull mistral
 
 Run the model server and create a volume mount into your localhost where the ollama models are stored. 
 ```bash
-podman run -it --rm -v /<LOCAL_PATH>/.ollama/:/root/.ollama:Z -p 11434:11434 ollama/ollama
+# Notes: $HOME/.ollama is the default ollama installation directory, but this may be different per person
+podman run -d -it --rm -v $HOME/.ollama:/root/.ollama:Z -p 11434:11434 ollama/ollama
 ```
 
 ### Interact with your models

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -1,58 +1,45 @@
-CHROMADBIMAGE ?= quay.io/ai-lab/chromadb:latest
-MODELIMAGE ?= quay.io/ai-lab/mistral-7b-instruct:latest
-APPIMAGE ?= quay.io/ai-lab/${APP}:latest
-SERVERIMAGE ?= quay.io/ai-lab/llamacpp-python:latest
-SSHPUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
-BOOTCIMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
+REGISTRY ?= quay.io
+IMAGE_NAME ?= ai-lab/${APP}:latest
+CHROMADB_IMAGE ?= $(REGISTRY)/ai-lab/chromadb:latest
+MODEL_IMAGE ?= $(REGISTRY)/ai-lab/mistral-7b-instruct:latest
+APP_IMAGE ?= $(REGISTRY)/$(IMAGE_NAME)
+SERVER_IMAGE ?= $(REGISTRY)/ai-lab/llamacpp-python:latest
+SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
+BOOTC_IMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
 FROM ?=
 ARCH ?=
 
 .PHONY: build
 build:
-	podman build $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} -f builds/Containerfile -t ${APPIMAGE} .
+	podman build $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} -f builds/Containerfile -t ${APP_IMAGE} .
 
 .PHONY: bootc
 bootc: quadlet
-	podman build $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSHPUBKEY=$(SSHPUBKEY)" -f bootc/Containerfile -t ${BOOTCIMAGE} .
+	podman build $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSH_PUBKEY=$(SSH_PUBKEY)" -f bootc/Containerfile -t ${BOOTC_IMAGE} .
 
 .PHONY: quadlet
 quadlet:
 	# Modify quadlet files to match the server, model and app image
 	mkdir -p build
-	sed -e "s|SERVERIMAGE|${SERVERIMAGE}|" \
-	    -e "s|APPIMAGE|${APPIMAGE}|g" \
-	    -e "s|MODELIMAGE|${MODELIMAGE}|g" \
-	    -e "s|CHROMADBIMAGE|${CHROMADBIMAGE}|g" \
+	sed -e "s|SERVER_IMAGE|${SERVER_IMAGE}|" \
+	    -e "s|APP_IMAGE|${APP_IMAGE}|g" \
+	    -e "s|MODEL_IMAGE|${MODEL_IMAGE}|g" \
+	    -e "s|CHROMADB_IMAGE|${CHROMADB_IMAGE}|g" \
 	    quadlet/${APP}.image \
 	    > build/${APP}.image
-	sed -e "s|SERVERIMAGE|${SERVERIMAGE}|" \
-	    -e "s|APPIMAGE|${APPIMAGE}|g" \
-	    -e "s|MODELIMAGE|${MODELIMAGE}|g" \
-	    -e "s|CHROMADBIMAGE|${CHROMADBIMAGE}|g" \
+	sed -e "s|SERVER_IMAGE|${SERVER_IMAGE}|" \
+	    -e "s|APP_IMAGE|${APP_IMAGE}|g" \
+	    -e "s|MODEL_IMAGE|${MODEL_IMAGE}|g" \
+	    -e "s|CHROMADB_IMAGE|${CHROMADB_IMAGE}|g" \
 	    quadlet/${APP}.yaml \
 	    > build/${APP}.yaml
 	cp quadlet/${APP}.kube build/${APP}.kube
 
-.PHONY: install
-install:
-	wget https://www.slimjetbrowser.com/chrome/files/103.0.5060.53/google-chrome-stable_current_amd64.deb
-	sudo dpkg -i google-chrome-stable_current_amd64.deb
-	wget https://chromedriver.storage.googleapis.com/103.0.5060.53/chromedriver_linux64.zip
-	unzip chromedriver_linux64.zip
-	pip install -r tests/requirements.txt
-
 .PHONY: run
 run: 
-	podman run -it -p 8501:8501 -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 ${APPIMAGE}
-
-.PHONY: functional_tests
-functional_tests:
-	python3 -m pytest -vvv --driver=Chrome --driver-path=./chromedriver tests/functional
-
-.PHONY: integration_test
-integration_tests:
-	URL=${URL} python3 -m pytest -vvv --driver=Chrome --driver-path=./chromedriver tests/integration
+	podman run -it -p 8501:8501 -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 ${APP_IMAGE}
 
 .PHONY: clean
 clean:
 	rm -rf build
+	-rm -rf tests/__pycache__

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -1,13 +1,39 @@
 REGISTRY ?= quay.io
-IMAGE_NAME ?= ai-lab/${APP}:latest
-CHROMADB_IMAGE ?= $(REGISTRY)/ai-lab/chromadb:latest
-MODEL_IMAGE ?= $(REGISTRY)/ai-lab/mistral-7b-instruct:latest
+REGISTRY_ORG ?= ai-lab
+
+IMAGE_NAME ?= $(REGISTRY_ORG)/${APP}:latest
+CHROMADB_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/chromadb:latest
+MODEL_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/mistral-7b-instruct:latest
 APP_IMAGE ?= $(REGISTRY)/$(IMAGE_NAME)
-SERVER_IMAGE ?= $(REGISTRY)/ai-lab/llamacpp-python:latest
+SERVER_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/llamacpp-python:latest
+
 SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
-BOOTC_IMAGE ?= quay.io/ai-lab/${APP}-bootc:latest
+BOOTC_IMAGE ?= quay.io/$(REGISTRY_ORG)/${APP}-bootc:latest
+
 FROM ?=
 ARCH ?=
+
+CHROMEDRIVER_VERSION := 103.0.5060.53
+CHROMEDRIVER_MIRROR := https://chromedriver.storage.googleapis.com
+CHROMEDRIVER_DOWNLOAD_PATH := 
+CHROMEDRIVER_INSTALLATION_PATH ?=
+
+OS := $(shell uname -s)
+ARCH := $(shell uname -m)
+
+ifeq ($(OS),Darwin) # This structure may vary if we upgrade chromedriver, see index: https://chromedriver.storage.googleapis.com/index.html
+	ifeq ($(ARCH),amd64)
+		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64.zip
+	else ifeq ($(ARCH),arm64)
+		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64_m1.zip
+	endif
+else ifeq ($(OS),Linux)
+	CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_linux64.zip
+endif
+
+CHROMEDRIVER_EXISTS ?= $(shell command -v chromedriver)
+LOCAL_CHROMEDRIVER_EXISTS ?= $(shell command -v $(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver)
+UNZIP_EXISTS ?= $(shell command -v unzip)
 
 .PHONY: build
 build:
@@ -16,6 +42,19 @@ build:
 .PHONY: bootc
 bootc: quadlet
 	podman build $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} --cap-add SYS_ADMIN --build-arg "SSH_PUBKEY=$(SSH_PUBKEY)" -f bootc/Containerfile -t ${BOOTC_IMAGE} .
+
+.PHONY: install-chromedriver
+install-chromedriver:
+	@if [[ -z "$(CHROMEDRIVER_EXISTS)" ]] && [[ -z "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
+		if [[ -n "$(UNZIP_EXISTS)" ]]; then \
+			curl -sLO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
+			unzip $(CHROMEDRIVER_DOWNLOAD_PATH); \
+			mv chromedriver $(CHROMEDRIVER_INSTALLATION_PATH); \
+			rm ./$(CHROMEDRIVER_DOWNLOAD_PATH); \
+		elif [[ -z "$(UNZIP_EXISTS)" ]]; then \
+			echo "Install make target requires unizp binary."; \
+		fi; \
+	fi;
 
 .PHONY: quadlet
 quadlet:
@@ -37,7 +76,7 @@ quadlet:
 
 .PHONY: run
 run: 
-	podman run -it -p 8501:8501 -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 ${APP_IMAGE}
+	podman run -it -p $(PORT):$(PORT) -e MODEL_SERVICE_ENDPOINT=http://10.88.0.1:8001/v1 ${APP_IMAGE}
 
 .PHONY: clean
 clean:

--- a/recipes/natural_language_processing/chatbot/Makefile
+++ b/recipes/natural_language_processing/chatbot/Makefile
@@ -1,3 +1,45 @@
 APP ?= chatbot
+PORT ?= 8501
 
 include ../../common/Makefile.common
+
+CHROMEDRIVER_EXISTS ?= $(shell command -v chromedriver)
+UNZIP_EXISTS ?= $(shell command -v unzip)
+
+CHROMEDRIVER_VERSION := 103.0.5060.53
+CHROMEDRIVER_MIRROR := https://chromedriver.storage.googleapis.com
+CHROMEDRIVER_DOWNLOAD_PATH := 
+
+OS := $(shell uname -s)
+ARCH := $(shell uname -m)
+
+ifeq ($(OS),Darwin) # This structure may vary if we upgrade chromedriver, see index: https://chromedriver.storage.googleapis.com/index.html
+	ifeq ($(ARCH),amd64)
+		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64.zip
+	else ifeq ($(ARCH),arm64)
+		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64_m1.zip
+	endif
+else ifeq ($(OS),Linux)
+	CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_linux64.zip
+endif
+
+.PHONY: install
+install:
+	@if [[ -z "$(CHROMEDRIVER_EXISTS)" ]]; then \
+		if [[ -n "$(UNZIP_EXISTS)" ]]; then \
+			curl -sLO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
+			unzip $(CHROMEDRIVER_DOWNLOAD_PATH); \
+			mv chromedriver /usr/local/bin/chromedriver; \
+		elif [[ -z "$(UNZIP_EXISTS)" ]]; then \
+			echo "Install make target requires unizp binary."; \
+		fi; \
+	fi; \
+	pip install -r tests/requirements.txt
+
+.PHONY: functional_tests
+functional_tests:
+	IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/functional
+
+.PHONY: integration_test
+integration_tests:
+	URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/integration

--- a/recipes/natural_language_processing/chatbot/Makefile
+++ b/recipes/natural_language_processing/chatbot/Makefile
@@ -3,43 +3,34 @@ PORT ?= 8501
 
 include ../../common/Makefile.common
 
-CHROMEDRIVER_EXISTS ?= $(shell command -v chromedriver)
-UNZIP_EXISTS ?= $(shell command -v unzip)
-
-CHROMEDRIVER_VERSION := 103.0.5060.53
-CHROMEDRIVER_MIRROR := https://chromedriver.storage.googleapis.com
-CHROMEDRIVER_DOWNLOAD_PATH := 
-
-OS := $(shell uname -s)
-ARCH := $(shell uname -m)
-
-ifeq ($(OS),Darwin) # This structure may vary if we upgrade chromedriver, see index: https://chromedriver.storage.googleapis.com/index.html
-	ifeq ($(ARCH),amd64)
-		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64.zip
-	else ifeq ($(ARCH),arm64)
-		CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_mac64_m1.zip
-	endif
-else ifeq ($(OS),Linux)
-	CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_linux64.zip
-endif
+CHROMEDRIVER_INSTALLATION_PATH := $(shell realpath ../..)
 
 .PHONY: install
 install:
-	@if [[ -z "$(CHROMEDRIVER_EXISTS)" ]]; then \
-		if [[ -n "$(UNZIP_EXISTS)" ]]; then \
-			curl -sLO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
-			unzip $(CHROMEDRIVER_DOWNLOAD_PATH); \
-			mv chromedriver /usr/local/bin/chromedriver; \
-		elif [[ -z "$(UNZIP_EXISTS)" ]]; then \
-			echo "Install make target requires unizp binary."; \
-		fi; \
-	fi; \
-	pip install -r tests/requirements.txt
+	$(MAKE) install-chromedriver CHROMEDRIVER_INSTALLATION_PATH=${CHROMEDRIVER_INSTALLATION_PATH}
+	pip install -q -r tests/requirements.txt
 
-.PHONY: functional_tests
-functional_tests:
-	IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/functional
+.PHONY: functional-tests
+functional-tests:
+	@if [[ -n "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
+		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver tests/functional; \
+	elif [[ -n "$(CHROMEDRIVER_EXISTS)" ]] && [[ -z "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
+		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/functional; \
+	else \
+		echo "fetching chromedriver"; \
+		make install; \
+		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver tests/functional; \
+	fi;
 
-.PHONY: integration_test
-integration_tests:
-	URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/integration
+.PHONY: integration-tests
+integration-tests:
+	@if [[ -n "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
+		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver tests/integration; \
+	elif [[ -n "$(CHROMEDRIVER_EXISTS)" ]] && [[ -z "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
+		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/integration; \
+	else \
+		echo "fetching chromedriver"; \
+		make install; \
+		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_EXISTS) tests/integration
+	fi;
+	


### PR DESCRIPTION
/cc @rhatdan @sallyom @lmilbaum 
ollama-ms changes:

- run model_server container in detached mode, path to default ollama config dir and add caveat about this in the docs

chatbot app makefile changes:

- rename variables for readability (ex: `MODELIMAGE` --> `MODEL_IMAGE`)
- reworked install for reliability and downloading from a trusted source
- fixing tests locally with python version collisions
- prepare variables for future image repo renaming/migration

