### PR TITLE
Add Containerfile.nocache for bootc images without pre pulled images.

### DIFF
--- a/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
@@ -24,10 +24,7 @@ ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
 
 # Add quadlet files to setup system to automatically run AI application on boot
-COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
-
-# Because images are prepulled, no need for .image quadlet
-# COPY build/${RECIPE}.image /usr/share/containers/systemd
+COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
@@ -36,10 +33,5 @@ RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
-
-# Prepull the model, model_server & application images to populate the system.
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
@@ -1,33 +1,27 @@
 # Example: an AI powered sample application is embedded as a systemd service
 # via Podman quadlet files in /usr/share/containers/systemd
 #
-# Use build command:
-# podman build --build-arg "sshpubkey=$(cat $HOME/.ssh/id_rsa.pub)" -t quay.io/exampleos/myos .
-# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
-# public key into the image, allowing root access via ssh.
+# from recipes/natural_language_processing/rag, run
+# 'make bootc'
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
+
 ARG SSHPUBKEY
 
+# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
+# public key into the image, allowing root access via ssh.
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
     echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
 
-# pre-pull workload images:
-# Comment the pull commands to keep bootc image smaller.
-# The quadlet .image file added above pulls following images on boot if not
-# pre-pulled here
-
-ARG RECIPE=codegen
+ARG RECIPE=rag
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
+ARG CHROMADBImage=quay.io/ai-lab/chromadb
 
 # Add quadlet files to setup system to automatically run AI application on boot
-COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
-
-# Because images are prepulled, no need for .image quadlet
-# COPY build/${RECIPE}.image /usr/share/containers/systemd
+COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
@@ -36,10 +30,5 @@ RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
-
-# Prepull the model, model_server & application images to populate the system.
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
@@ -1,33 +1,25 @@
 # Example: an AI powered sample application is embedded as a systemd service
 # via Podman quadlet files in /usr/share/containers/systemd
 #
-# Use build command:
-# podman build --build-arg "sshpubkey=$(cat $HOME/.ssh/id_rsa.pub)" -t quay.io/exampleos/myos .
-# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
-# public key into the image, allowing root access via ssh.
+# from recipes/natural_language_processing/summarizer, run
+# 'make bootc'
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
 
+# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
+# public key into the image, allowing root access via ssh.
 RUN mkdir /usr/etc-system && \
     echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
     echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
 
-# pre-pull workload images:
-# Comment the pull commands to keep bootc image smaller.
-# The quadlet .image file added above pulls following images on boot if not
-# pre-pulled here
-
-ARG RECIPE=codegen
+ARG RECIPE=summarizer
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
 
 # Add quadlet files to setup system to automatically run AI application on boot
-COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
-
-# Because images are prepulled, no need for .image quadlet
-# COPY build/${RECIPE}.image /usr/share/containers/systemd
+COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
@@ -36,10 +28,5 @@ RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
-
-# Prepull the model, model_server & application images to populate the system.
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null


### PR DESCRIPTION
These images can easily be used by setting
CONTAINERFILE=Containerfile.nocache in the Makefile.