### PR TITLE
create workflow for calling cointainers-mirror workflows

### DIFF
--- a/.github/workflows/call-target-workflow.yaml
+++ b/.github/workflows/call-target-workflow.yaml
@@ -1,0 +1,78 @@
+name: Trigger Target Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger_chatbot_workflow:
+        description: 'Boolean: Trigger chatbot workflow in mirror repo?'
+        type: choice
+        options: [true, false]
+        required: true
+      trigger_model_servers_workflow:
+        description: 'Boolean: Trigger model_servers workflow in mirror repo?'
+        type: choice
+        required: true
+        options: [true, false]
+      trigger_mirror_repository:
+        description: 'Boolean: Trigger mirror_repository workflow in containers repo?'
+        type: choice
+        required: true
+        options: [true, false]
+      git_ref:
+        description: 'The desired reference to trigger the pipelines with'
+        required: true
+
+jobs:
+  trigger_mirror_repository:
+    if: github.event.inputs.trigger_mirror_repository == true
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPO_OWNER: containers
+      REPO_NAME: ai-lab-recipes
+      WORKFLOW_ID: 92734077
+    steps:
+      - name: rigger mirror_repository workflow in the containers owned repo
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.TARGET_REPO_OWNER }}/${{ env.REPO_NAME }}/actions/workflows/${{ env.WORKFLOW_ID}}/dispatches \
+            -d '{"ref":"'${{ github.event.inputs.git_ref }}'"}'
+  
+  trigger_model_servers_workflow:
+    if: github.event.inputs.trigger_model_servers_workflow == true
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPO_OWNER: containers-mirror
+      REPO_NAME: ai-lab-recipes
+      WORKFLOW_ID: 92726074
+    steps:
+      - name: Trigger model_servers workflow in the containers-mirror owned repo
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.TARGET_REPO_OWNER }}/${{ env.REPO_NAME }}/actions/workflows/${{ env.WORKFLOW_ID}}/dispatches \
+            -d '{"ref":"'${{ github.event.inputs.git_ref }}'"}'
+
+  trigger_chatbot_workflow:
+    if: github.event.inputs.trigger_chatbot_workflow == true
+    runs-on: ubuntu-latest
+    env:
+      TARGET_REPO_OWNER: containers-mirror
+      REPO_NAME: ai-lab-recipes
+      WORKFLOW_ID: 92726072
+    steps:
+      - name: Trigger chatbot workflow in the containers-mirror owned repo
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ env.TARGET_REPO_OWNER }}/${{ env.REPO_NAME }}/actions/workflows/${{ env.WORKFLOW_ID}}/dispatches \
+            -d '{"ref":"'${{ github.event.inputs.git_ref }}'"}'


### PR DESCRIPTION
/cc @lmilbaum @sallyom This should allow us to call workflows in the other repo however it requires a `secrets.PAT` to be created for a personal access token that has permission to create `workflow_dispatches`. Maybe we do this for a bot user?
