### PR TITLE
make bootc needs to use the bootc context dir

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -72,7 +72,7 @@ bootc: quadlet
 	  --build-arg "SSHPUBKEY=$(SSH_PUBKEY)" \
 	  -v /etc/containers/policy.json:/etc/containers/policy.json \
 	  -f bootc/$(CONTAINERFILE) \
-	  -t ${BOOTC_IMAGE} .
+	  -t ${BOOTC_IMAGE} bootc
 	@echo ""
 	@echo "Successfully built bootc image '${BOOTC_IMAGE}'."
 	@echo "You may now convert the image into a disk image via bootc-image-builder"


### PR DESCRIPTION
Colin found this broken on remote clients on a
Mac. Works on local systems, but not podman --remote.