### PR TITLE
tree-wide: Update SSH key injection

### DIFF
--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=chatbot
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=chatbot
 

--- a/recipes/natural_language_processing/codegen/bootc/Containerfile
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile
@@ -9,9 +9,9 @@
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
 
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 # pre-pull workload images:
 # Comment the pull commands to keep bootc image smaller.

--- a/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=codegen
 

--- a/recipes/natural_language_processing/rag/bootc/Containerfile
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile
@@ -10,9 +10,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=rag
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest

--- a/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=rag
 

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=summarizer
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
@@ -9,9 +9,9 @@ ARG SSHPUBKEY
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
-RUN mkdir /usr/etc-system && \
-    echo 'AuthorizedKeysFile /usr/etc-system/%u.keys' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
-    echo ${SSHPUBKEY} > /usr/etc-system/root.keys && chmod 0600 /usr/etc-system/root.keys
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 ARG RECIPE=summarizer
 


### PR DESCRIPTION
This is an improved reference example that fixes two things:

- Error out if SSHPUBKEY is not provided or empty (via `set -eu`)
- Also reads any keys in the traditional location (i.e. `/root/.ssh`) so that keys injected via other mechanisms (e.g. cloud-init, podman-bootc CLI) also work

(Are we at the point where we should have a script that generates
 these Containerfiles?)