### PR TITLE
fix image tagging with registry / registry_org

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -3,7 +3,6 @@ name: Update quay.io/ai-lab model images
 on:
   schedule: # schedule the job to run at 12 AM daily
    - cron: '0 0 * * *'
-
   pull_request:
     branches:
       - main


### PR DESCRIPTION
/cc @lmilbaum [The last run of this action](https://github.com/containers/ai-lab-recipes/actions/runs/8654943431/job/23733073760#step:5:33) running the following command and resulting in the following error: 
```bash
/usr/bin/buildah bud --platform linux/amd64 -f /home/runner/work/ai-lab-recipes/ai-lab-recipes/models/convert_models/Containerfile --format docker --tls-verify=true -t model-converter:latest-linuxamd64 /home/runner/work/ai-lab-recipes/ai-lab-recipes/models/convert_models
error evaluating symlinks in build context path: lstat /home/runner/work/ai-lab-recipes/ai-lab-recipes/models/convert_models: no such file or directory
```

This PR changes:

1. [update the tagging](https://github.com/containers/ai-lab-recipes/compare/main...Gregory-Pereira:ai-lab-recipes:fix-model-image-build-push-workflow?expand=1#diff-9bf30cac94aa49cc053ae656f952d6eb8d56dade7d7a545b1f7cdf0c6bfb9c75R61) of the image in the build command to be: `quay.io/ai-lab/model-converter:latest`
2. [fix the pathing](https://github.com/containers/ai-lab-recipes/compare/main...Gregory-Pereira:ai-lab-recipes:fix-model-image-build-push-workflow?expand=1#diff-9bf30cac94aa49cc053ae656f952d6eb8d56dade7d7a545b1f7cdf0c6bfb9c75L46-R65) on the build step
3. [add better build constraints](https://github.com/containers/ai-lab-recipes/pull/257/files#diff-9bf30cac94aa49cc053ae656f952d6eb8d56dade7d7a545b1f7cdf0c6bfb9c75R6-R23) to hopefully reduce our workflows once we drop the cronschedule
4. unrelated houskeeping on `.gitignore`