### PR TITLE
fixing passing port as a build argument to containers

### DIFF
--- a/model_servers/common/Makefile.common
+++ b/model_servers/common/Makefile.common
@@ -10,7 +10,7 @@ endif
 
 .PHONY: build
 build:
-	podman build --squash-all --build-arg $(PORT) -t $(IMAGE) . -f base/Containerfile
+	podman build --squash-all --build-arg PORT=$(PORT) -t $(IMAGE) . -f base/Containerfile
 
 .PHONY: install
 install:

--- a/model_servers/llamacpp_python/base/Containerfile
+++ b/model_servers/llamacpp_python/base/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8001
 WORKDIR /locallm
 COPY src .
 RUN pip install --no-cache-dir --verbose -r ./requirements.txt
-EXPOSE 8001
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "./run.sh" ]

--- a/model_servers/llamacpp_python/cuda/Containerfile
+++ b/model_servers/llamacpp_python/cuda/Containerfile
@@ -1,8 +1,10 @@
 FROM quay.io/opendatahub/workbench-images:cuda-ubi9-python-3.9-20231206
+ARG PORT=8001
 WORKDIR /locallm
 COPY src .
 RUN pip install --upgrade pip
 ENV CMAKE_ARGS="-DLLAMA_CUBLAS=on"
 ENV FORCE_CMAKE=1
 RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/llamacpp_python/vulkan/Containerfile
+++ b/model_servers/llamacpp_python/vulkan/Containerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
 USER 0
+ARG PORT=8001
 RUN dnf install -y python3-dnf-plugin-versionlock && \
     dnf copr enable -y slp/mesa-krunkit epel-9-aarch64 && \
     dnf install -y mesa-vulkan-drivers-23.3.3-101.el9.aarch64 && \
@@ -12,4 +13,5 @@ RUN pip install --upgrade pip
 ENV CMAKE_ARGS="-DLLAMA_VULKAN=on"
 ENV FORCE_CMAKE=1
 RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as builder
-
+ARG PORT=8001
 WORKDIR /app
 RUN dnf install -y git make gcc gcc-c++
 RUN mkdir whisper && cd whisper && git clone https://github.com/ggerganov/whisper.cpp.git . && \
@@ -21,4 +21,5 @@ COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
 COPY src /app/
 ENV AUDIO_FILE=/app/jfk.wav
+EXPOSE $PORT
 ENTRYPOINT ["sh", "run.sh"]

--- a/recipes/audio/audio_to_text/app/Containerfile
+++ b/recipes/audio/audio_to_text/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /locallm
 COPY requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade -r requirements.txt
 COPY whisper_client.py whisper_client.py
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "whisper_client.py" ]

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -75,7 +75,7 @@ install::
 
 .PHONY: build
 build:
-	podman build --squash-all $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} -t ${APP_IMAGE} app/
+	podman build --squash-all $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} --build-arg PORT=$(PORT) -t ${APP_IMAGE} app/
 
 .PHONY: bootc
 bootc: quadlet
@@ -85,6 +85,7 @@ bootc: quadlet
 	  $${AUTH_JSON:+-v $${AUTH_JSON}:/run/containers/0/auth.json} \
 	  --security-opt label=disable \
 	  --cap-add SYS_ADMIN \
+	  $${PORT:+--build-arg PORT=$${PORT}} \
 	  --build-arg MODEL_IMAGE=$(MODEL_IMAGE) \
 	  --build-arg APP_IMAGE=$(APP_IMAGE) \
 	  --build-arg SERVER_IMAGE=$(SERVER_IMAGE) \
@@ -101,7 +102,7 @@ bootc: quadlet
 
 .PHONY: bootc-run
 bootc-run:
-	podman run -d --rm --name $(APP)-bootc -p 8080:8501 --privileged \
+	podman run -d --rm --name $(APP)-bootc -p 8080:$(PORT) --privileged \
 	  $${AUTH_JSON:+-v $${AUTH_JSON}:/run/containers/0/auth.json} \
 	  $(BOOTC_IMAGE) /sbin/init
 

--- a/recipes/computer_vision/object_detection/client/Containerfile
+++ b/recipes/computer_vision/object_detection/client/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /locallm
 COPY requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade -r requirements.txt
 COPY object_detection_client.py object_detection_client.py
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "object_detection_client.py" ]

--- a/recipes/computer_vision/object_detection/model_server/Containerfile
+++ b/recipes/computer_vision/object_detection/model_server/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8001
 WORKDIR /locallm
 COPY requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade -r requirements.txt
 COPY object_detection_server.py object_detection_server.py
-EXPOSE 8000
+EXPOSE $PORT
 ENTRYPOINT [ "uvicorn", "object_detection_server:app", "--host", "0.0.0.0" ]

--- a/recipes/computer_vision/object_detection/model_server/Containerfile
+++ b/recipes/computer_vision/object_detection/model_server/Containerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
-ARG PORT=8001
+ARG PORT=8000
 WORKDIR /locallm
 COPY requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip && \

--- a/recipes/multimodal/image_understanding/app/Containerfile
+++ b/recipes/multimodal/image_understanding/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /image_understanding
 COPY requirements.txt .
 RUN pip install --upgrade pip && \
   pip install --no-cache-dir --upgrade -r requirements.txt
 COPY image_understanding.py .
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "image_understanding.py" ]

--- a/recipes/natural_language_processing/chatbot/app/Containerfile
+++ b/recipes/natural_language_processing/chatbot/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /chat
 COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /chat/requirements.txt
 COPY chatbot_ui.py .
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "chatbot_ui.py" ]

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -40,5 +41,7 @@ VOLUME /var/lib/containers
 RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+
+EXPOSE $PORT
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -17,6 +18,8 @@ ARG RECIPE=chatbot
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
+
+EXPOSE $PORT
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers

--- a/recipes/natural_language_processing/codegen/app/Containerfile
+++ b/recipes/natural_language_processing/codegen/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /codegen
 COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /codegen/requirements.txt
 COPY codegen-app.py .
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT ["streamlit", "run", "codegen-app.py"]

--- a/recipes/natural_language_processing/codegen/bootc/Containerfile
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile
@@ -8,6 +8,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 RUN set -eu; mkdir -p /usr/ssh && \
     echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
@@ -41,5 +42,7 @@ VOLUME /var/lib/containers
 RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+
+EXPOSE $PORT
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile.nocache
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -17,6 +18,8 @@ ARG RECIPE=codegen
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
+
+EXPOSE $PORT
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers

--- a/recipes/natural_language_processing/rag/app/Containerfile
+++ b/recipes/natural_language_processing/rag/app/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 ### Update sqlite for chroma
 USER root
 RUN dnf remove sqlite3 -y
@@ -16,6 +17,6 @@ COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /rag/requirements.txt
 COPY rag_app.py .
-EXPOSE  8501
+EXPOSE $PORT
 ENV  HF_HUB_CACHE=/rag/models/
 ENTRYPOINT [ "streamlit", "run" ,"rag_app.py" ]

--- a/recipes/natural_language_processing/rag/bootc/Containerfile
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile
@@ -5,8 +5,8 @@
 # 'make bootc'
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
-
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -43,5 +43,7 @@ RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${CHROMADBImage}
+
+EXPOSE $PORT
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile.nocache
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -17,6 +18,8 @@ ARG RECIPE=rag
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
+
+EXPOSE $PORT
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers

--- a/recipes/natural_language_processing/summarizer/app/Containerfile
+++ b/recipes/natural_language_processing/summarizer/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT=8501
 WORKDIR /summarizer
 COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /summarizer/requirements.txt
 COPY summarizer.py .
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "summarizer.py" ]

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -40,5 +41,7 @@ VOLUME /var/lib/containers
 RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
 RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+
+EXPOSE $PORT
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile.nocache
@@ -6,6 +6,7 @@
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
+ARG PORT=8501
 
 # The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
 # public key into the image, allowing root access via ssh.
@@ -17,6 +18,8 @@ ARG RECIPE=summarizer
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
+
+EXPOSE $PORT
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers


### PR DESCRIPTION
I discovered when playing around with builds that the way we were passing `PORT` arguments wasnt working, because we both were exposing a static port number in the `Containerfile` and because we were passing the actual argument for it incorrectly:

```bash
# Tested from the `object_detection_python` model_server but all builds were the same
$ make PORT=20203 build
podman build --squash-all \
	  --build-arg PORT=20203 \
	  -t quay.io/ai-lab/model_servers/object_detection_python:latest . -f base/Containerfile
...
STEP 6/7: EXPOSE 8000
...
Successfully tagged quay.io/ai-lab/model_servers/object_detection_python:latest
bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
```
Then verified inspecting the image:

```bash
podman inspect bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
...
"ExposedPorts": {
    "8000/tcp": {},
    "8080/tcp": {}
},
```

The new builds produce the following:
```bash
$ make PORT=20203 build
...
STEP 2/8: ARG PORT
...
STEP 7/8: EXPOSE $PORT
...
Successfully tagged quay.io/ai-lab/model_servers/object_detection_python:latest
bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
$ podman inspect bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
...
"ExposedPorts": {
    "20203/tcp": {},
    "8080/tcp": {}
},
```