### PR TITLE
fixing passing port as a build argument to containers

### DIFF
--- a/model_servers/common/Makefile.common
+++ b/model_servers/common/Makefile.common
@@ -10,7 +10,7 @@ endif
 
 .PHONY: build
 build:
-	podman build --squash-all --build-arg $(PORT) -t $(IMAGE) . -f base/Containerfile
+	podman build --squash-all --build-arg PORT=$(PORT) -t $(IMAGE) . -f base/Containerfile
 
 .PHONY: install
 install:

--- a/model_servers/llamacpp_python/base/Containerfile
+++ b/model_servers/llamacpp_python/base/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT
 WORKDIR /locallm
 COPY src .
 RUN pip install --no-cache-dir --verbose -r ./requirements.txt
-EXPOSE 8001
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "./run.sh" ]

--- a/model_servers/llamacpp_python/cuda/Containerfile
+++ b/model_servers/llamacpp_python/cuda/Containerfile
@@ -1,8 +1,10 @@
 FROM quay.io/opendatahub/workbench-images:cuda-ubi9-python-3.9-20231206
+ARG PORT
 WORKDIR /locallm
 COPY src .
 RUN pip install --upgrade pip
 ENV CMAKE_ARGS="-DLLAMA_CUBLAS=on"
 ENV FORCE_CMAKE=1
 RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/llamacpp_python/vulkan/Containerfile
+++ b/model_servers/llamacpp_python/vulkan/Containerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
 USER 0
+ARG PORT
 RUN dnf install -y python3-dnf-plugin-versionlock && \
     dnf copr enable -y slp/mesa-krunkit epel-9-aarch64 && \
     dnf install -y mesa-vulkan-drivers-23.3.3-101.el9.aarch64 && \
@@ -12,4 +13,5 @@ RUN pip install --upgrade pip
 ENV CMAKE_ARGS="-DLLAMA_VULKAN=on"
 ENV FORCE_CMAKE=1
 RUN pip install --no-cache-dir --upgrade -r /locallm/requirements.txt
+EXPOSE $PORT
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest as builder
-
+ARG PORT
 WORKDIR /app
 RUN dnf install -y git make gcc gcc-c++
 RUN mkdir whisper && cd whisper && git clone https://github.com/ggerganov/whisper.cpp.git . && \
@@ -21,4 +21,5 @@ COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
 COPY src /app/
 ENV AUDIO_FILE=/app/jfk.wav
+EXPOSE $PORT
 ENTRYPOINT ["sh", "run.sh"]

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -75,7 +75,7 @@ install:
 
 .PHONY: build
 build:
-	podman build --squash-all $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} -t ${APP_IMAGE} app/
+	podman build --squash-all $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} --build-arg PORT=$(PORT) -t ${APP_IMAGE} app/
 
 .PHONY: bootc
 bootc: quadlet

--- a/recipes/computer_vision/object_detection/model_server/Containerfile
+++ b/recipes/computer_vision/object_detection/model_server/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT
 WORKDIR /locallm
 COPY requirements.txt /locallm/requirements.txt
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir --upgrade -r requirements.txt
-COPY object_detection_server.py object_detection_server.py
-EXPOSE 8000
+COPY ../src/object_detection_server.py object_detection_server.py
+EXPOSE $PORT
 ENTRYPOINT [ "uvicorn", "object_detection_server:app", "--host", "0.0.0.0" ]

--- a/recipes/natural_language_processing/chatbot/app/Containerfile
+++ b/recipes/natural_language_processing/chatbot/app/Containerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52
+ARG PORT
 WORKDIR /chat
 COPY requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --upgrade -r /chat/requirements.txt
 COPY chatbot_ui.py .
-EXPOSE 8501
+EXPOSE $PORT
 ENTRYPOINT [ "streamlit", "run", "chatbot_ui.py" ]


### PR DESCRIPTION
Re-opening #258 on upstream branch because tests weren't working from my fork. Guessing this is some funkyness resulting from toggling `actions` off then back on in my fork.

I discovered when playing around with builds that the way we were passing `PORT` arguments wasnt working, because we both were exposing a static port number in the `Containerfile` and because we were passing the actual argument for it incorrectly:

```bash
# Tested from the `object_detection_python` model_server but all builds were the same
$ make PORT=20203 build
podman build --squash-all \
	  --build-arg PORT=20203 \
	  -t quay.io/ai-lab/model_servers/object_detection_python:latest . -f base/Containerfile
...
STEP 6/7: EXPOSE 8000
...
Successfully tagged quay.io/ai-lab/model_servers/object_detection_python:latest
bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
```
Then verified inspecting the image:

```bash
podman inspect bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
...
"ExposedPorts": {
    "8000/tcp": {},
    "8080/tcp": {}
},
```

The new builds produce the following:
```bash
$ make PORT=20203 build
...
STEP 2/8: ARG PORT
...
STEP 7/8: EXPOSE $PORT
...
Successfully tagged quay.io/ai-lab/model_servers/object_detection_python:latest
bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
$ podman inspect bd834bd87c2605cf5e0cc93ee3e4c23c9b7fb030040cea6eb56b0e401efd4e27
...
"ExposedPorts": {
    "20203/tcp": {},
    "8080/tcp": {}
},
```