### PR TITLE
include common directory in tests on path changes

### DIFF
--- a/.github/workflows/chatbot.yaml
+++ b/.github/workflows/chatbot.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/chatbot/**
       - .github/workflows/chatbot.yaml
   push:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/chatbot/**
       - .github/workflows/chatbot.yaml
 
@@ -22,6 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/codegen/**
       - .github/workflows/codegen.yaml
   push:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/codegen/**
       - .github/workflows/codegen.yaml
 
@@ -22,6 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,8 +62,8 @@ jobs:
         run: make install
 
       - name: Download model
-        working-directory: ./model_servers/llamacpp_python
-        run: make mistral
+        working-directory: ./recipes/natural_language_processing/${{ env.IMAGE_NAME }}
+        run: make download-model-mistral
 
       - name: Run Functional Tests
         shell: bash

--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-and-push-model-converter-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,6 +62,7 @@ jobs:
           tags: ${{ steps.build_convert_models_image.outputs.tags }}
 
   build-and-push-mistral-model-image:
+    if: contains( github.event.pull_request.labels.*.name, 'hold-tests')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/model_servers.yaml
+++ b/.github/workflows/model_servers.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - ./model_servers/
+      - ./model_servers/**
       - .github/workflows/model_servers.yaml
   push:
     branches:
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     strategy:
       matrix:
         include:

--- a/.github/workflows/rag.yaml
+++ b/.github/workflows/rag.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/rag/**
       - .github/workflows/rag.yaml
   push:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/rag/**
       - .github/workflows/rag.yaml
 
@@ -22,6 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,8 +67,8 @@ jobs:
         run: make install
 
       - name: Download model
-        working-directory: ./model_servers/llamacpp_python
-        run: make mistral
+        working-directory: ./recipes/natural_language_processing/${{ env.IMAGE_NAME }}
+        run: make download-model-mistral
 
       - name: Run Functional Tests
         shell: bash

--- a/.github/workflows/summarizer.yaml
+++ b/.github/workflows/summarizer.yaml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/summarizer/**
       - .github/workflows/summarizer.yaml
   push:
     branches:
       - main
     paths:
+      - ./recipes/common/Makefile.common
       - ./recipes/natural_language_processing/summarizer/**
       - .github/workflows/summarizer.yaml
 
@@ -22,6 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,8 +62,8 @@ jobs:
         run: make install
 
       - name: Download model
-        working-directory: ./model_servers/llamacpp_python
-        run: make mistral
+        working-directory: ./recipes/natural_language_processing/${{ env.IMAGE_NAME }}
+        run: make download-model-mistral
 
       - name: Run Functional Tests
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ models/*
 !models/Makefile
 !models/README.md
 convert_models/converted_models
-recipes/chromedriver
-recipes/Google\ Chrome.app
+recipes/common/bin/*
+*/.venv/

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -31,7 +31,7 @@ endif
 CHROMEDRIVER_VERSION := 103.0.5060.53
 CHROMEDRIVER_MIRROR := https://chromedriver.storage.googleapis.com
 CHROMEDRIVER_DOWNLOAD_PATH := 
-CHROMEDRIVER_INSTALLATION_PATH ?=
+RECIPE_BINARIES_PATH ?=
 CHROME_DOWNLOAD_PATH ?=
 
 OS := $(shell uname -s)
@@ -51,7 +51,7 @@ endif
 
 CHROME_MIRROR := https://www.slimjet.com/chrome/files/$(CHROMEDRIVER_VERSION)/$(CHROME_DOWNLOAD_PATH)
 
-LOCAL_CHROMEDRIVER_EXISTS ?= $(shell command -v $(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver)
+LOCAL_CHROMEDRIVER_EXISTS ?= $(shell command -v $(RECIPE_BINARIES_PATH)/chromedriver)
 UNZIP_EXISTS ?= $(shell command -v unzip)
 
 RELATIVE_MODELS_PATH := ?=
@@ -68,9 +68,9 @@ download-model-mistral:
 	make MODEL_NAME=mistral-7b-instruct-v0.1.Q4_K_M.gguf MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf -f  Makefile download-model
 
 .PHONY: install
-install:
-	$(MAKE) install-chromedriver CHROMEDRIVER_INSTALLATION_PATH=${CHROMEDRIVER_INSTALLATION_PATH}
-	$(MAKE) install-chrome CHROMEDRIVER_INSTALLATION_PATH=${CHROMEDRIVER_INSTALLATION_PATH}
+install::
+	$(MAKE) install-chromedriver RECIPE_BINARIES_PATH=${RECIPE_BINARIES_PATH}
+	$(MAKE) install-chrome RECIPE_BINARIES_PATH=${RECIPE_BINARIES_PATH}
 	pip install -q -r ${RELATIVE_TESTS_PATH}/requirements.txt
 
 .PHONY: build
@@ -129,9 +129,9 @@ bootc-image-builder: bootc
 install-chromedriver:
 	@if [[ -z "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
 		if [[ -n "$(UNZIP_EXISTS)" ]]; then \
-			curl -sLO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
+			curl --max-time 300 --connect-timeout 60 -sLO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
 			unzip $(CHROMEDRIVER_DOWNLOAD_PATH); \
-			mv chromedriver $(CHROMEDRIVER_INSTALLATION_PATH); \
+			mv chromedriver $(RECIPE_BINARIES_PATH)/; \
 			rm ./$(CHROMEDRIVER_DOWNLOAD_PATH); \
 		elif [[ -z "$(UNZIP_EXISTS)" ]]; then \
 			echo "Install make target requires unizp binary."; \
@@ -141,14 +141,15 @@ install-chromedriver:
 
 .PHONY: install-chrome
 install-chrome:
-	curl -sLO $(CHROME_MIRROR)
+	curl --max-time 300 --connect-timeout 60 -sLO $(CHROME_MIRROR)
 	@if [[ "$(OS)" == "Linux" ]]; then \
 		sudo dpkg -i $(CHROME_DOWNLOAD_PATH); \
 	elif [[ "$(OS)" == "Darwin" ]]; then \
 		open $(CHROME_DOWNLOAD_PATH); \
+		ls "/Volumes/Google Chrome/Google Chrome.app/Contents/MacOS/Google Chrome"; \
+		cp -r "/Volumes/Google Chrome/Google Chrome.app" "$(RECIPE_BINARIES_PATH)/"; \
+		diskutil unmount "/Volumes/Google Chrome" || true; \
 		rm $(CHROME_DOWNLOAD_PATH); \
-		cp -r /Volumes/Google\ Chrome/Google\ Chrome.app $(CHROMEDRIVER_INSTALLATION_PATH); \
-		diskutil unmount /Volumes/Google\ Chrome; \
 	fi;
 
 .PHONY: quadlet
@@ -193,20 +194,20 @@ check-model-in-path:
 functional-tests:
 	$(MAKE) MODEL_NAME=$(MODEL_NAME) check-model-in-path 
 	@if [[ -n "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
-		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} MODEL_NAME=${MODEL_NAME} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/functional; \
+		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} MODEL_NAME=${MODEL_NAME} pytest -vvv --driver=Chrome --driver-path=$(RECIPE_BINARIES_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/functional; \
 	else \
 		echo "fetching chromedriver"; \
 		make install; \
-		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} MODEL_NAME=${MODEL_NAME} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/functional; \
+		IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} MODEL_NAME=${MODEL_NAME} pytest -vvv --driver=Chrome --driver-path=$(RECIPE_BINARIES_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/functional; \
 	fi;
 
 .PHONY: integration-tests
 integration-tests:
 	@if [[ -n "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
-		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/integration; \
+		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(RECIPE_BINARIES_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/integration; \
 	else \
 		echo "fetching chromedriver"; \
 		make install; \
-		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(CHROMEDRIVER_INSTALLATION_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/integration; \
+		URL=${URL} IMAGE_NAME=${IMAGE_NAME} REGISTRY=${REGISTRY} pytest -vvv --driver=Chrome --driver-path=$(RECIPE_BINARIES_PATH)/chromedriver ${RELATIVE_TESTS_PATH}/integration; \
 	fi;
 

--- a/recipes/natural_language_processing/chatbot/Makefile
+++ b/recipes/natural_language_processing/chatbot/Makefile
@@ -4,6 +4,6 @@ PORT ?= 8501
 
 include ../../common/Makefile.common
 
-CHROMEDRIVER_INSTALLATION_PATH := $(shell realpath ../..)
+RECIPE_BINARIES_PATH := $(shell realpath ../../common/bin)
 RELATIVE_MODELS_PATH := ../../../models
 RELATIVE_TESTS_PATH := ../tests

--- a/recipes/natural_language_processing/codegen/Makefile
+++ b/recipes/natural_language_processing/codegen/Makefile
@@ -4,6 +4,6 @@ PORT ?= 8501
 
 include ../../common/Makefile.common
 
-CHROMEDRIVER_INSTALLATION_PATH := $(shell realpath ../..)
+RECIPE_BINARIES_PATH := $(shell realpath ../../common/bin)
 RELATIVE_MODELS_PATH := ../../../models
 RELATIVE_TESTS_PATH := ../tests

--- a/recipes/natural_language_processing/rag/Makefile
+++ b/recipes/natural_language_processing/rag/Makefile
@@ -5,7 +5,7 @@ CHROMADB_PORT ?= 8000
 
 include ../../common/Makefile.common
 
-CHROMEDRIVER_INSTALLATION_PATH := $(shell realpath ../..)
+RECIPE_BINARIES_PATH := $(shell realpath ../../common/bin)
 RELATIVE_MODELS_PATH := ../../../models
 RELATIVE_TESTS_PATH := ../tests
 

--- a/recipes/natural_language_processing/summarizer/Makefile
+++ b/recipes/natural_language_processing/summarizer/Makefile
@@ -4,6 +4,6 @@ PORT ?= 8501
 
 include ../../common/Makefile.common
 
-CHROMEDRIVER_INSTALLATION_PATH := $(shell realpath ../..)
+RECIPE_BINARIES_PATH := $(shell realpath ../../common/bin)
 RELATIVE_MODELS_PATH := ../../../models
 RELATIVE_TESTS_PATH := ../tests

--- a/recipes/natural_language_processing/tests/conftest.py
+++ b/recipes/natural_language_processing/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixing tests, will also use this PR to fix any code changes that correspond to failing tests. 

Broken out from #258.

Changes:

- add a check on jobs in the standard development workflows (all apps, model_servers, model_image_build_push) to not run if there is a `hold-tests` label, I thought this could save us some resources
- fix `codegen`'s `Download model` step due changing make target name
- fix `chromedriver` and `chrome`  downloads failling due to timeout
    - move binaries to `/recipes/common/bin`
- swapped `install` make target in both `recipes/common` and each recipe to be a [double colon rule](https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html#:~:text=4.13%20Double%2DColon%20Rules&text=When%20a%20target%20appears%20in,any%20prerequisites%20of%20that%20rule.) rather than a single colon rule, which allows us to run common and local install commands together