### PR TITLE
Fix ARCH= option for bootc images.

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -75,7 +75,7 @@ install::
 
 .PHONY: build
 build:
-	podman build --squash-all $${ARCH:+--arch $${ARCH}} $${FROM:+--from $${FROM}} -t ${APP_IMAGE} app/
+	podman build --squash-all $${ARCH:+--platform linux/$${ARCH}} $${FROM:+--from $${FROM}} -t ${APP_IMAGE} app/
 
 .PHONY: bootc
 bootc: quadlet

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile
@@ -17,6 +17,7 @@ ARG RECIPE=chatbot
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
+ARG TARGETARCH
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
@@ -37,8 +38,9 @@ VOLUME /var/lib/containers
 # Prepull the model, model_server & application images to populate the system.
 # Comment the pull commands to keep bootc image smaller.
 # The quadlet .image file added above pulls following images with service startup
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${SERVER_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${APP_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/codegen/bootc/Containerfile
+++ b/recipes/natural_language_processing/codegen/bootc/Containerfile
@@ -1,32 +1,30 @@
 # Example: an AI powered sample application is embedded as a systemd service
 # via Podman quadlet files in /usr/share/containers/systemd
 #
-# Use build command:
-# podman build --build-arg "sshpubkey=$(cat $HOME/.ssh/id_rsa.pub)" -t quay.io/exampleos/myos .
-# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
-# public key into the image, allowing root access via ssh.
+# from recipes/natural_language_processing/codegen, run
+# 'make bootc'
 
 FROM quay.io/centos-bootc/centos-bootc:stream9
 ARG SSHPUBKEY
 
+# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
+# public key into the image, allowing root access via ssh.
 RUN set -eu; mkdir -p /usr/ssh && \
     echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
     echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
-
-# pre-pull workload images:
-# Comment the pull commands to keep bootc image smaller.
-# The quadlet .image file added above pulls following images on boot if not
-# pre-pulled here
 
 ARG RECIPE=codegen
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
+ARG TARGETARCH
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 
 # Because images are prepulled, no need for .image quadlet
+# If commenting out the pulls below, uncomment this to track the images
+# so the systemd service will wait for the images with the service startup
 # COPY build/${RECIPE}.image /usr/share/containers/systemd
 
 # Setup /usr/lib/containers/storage as an additional store for images.
@@ -38,8 +36,11 @@ RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 VOLUME /var/lib/containers
 
 # Prepull the model, model_server & application images to populate the system.
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+# Comment the pull commands to keep bootc image smaller.
+# The quadlet .image file added above pulls following images with service startup
+
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${SERVER_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${APP_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/rag/bootc/Containerfile
+++ b/recipes/natural_language_processing/rag/bootc/Containerfile
@@ -19,6 +19,7 @@ ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
 ARG CHROMADBImage=quay.io/ai-lab/chromadb
+ARG TARGETARCH
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
@@ -39,9 +40,9 @@ VOLUME /var/lib/containers
 # Prepull the model, model_server & application images to populate the system.
 # Comment the pull commands to keep bootc image smaller.
 # The quadlet .image file added above pulls following images with service startup
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${CHROMADBImage}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${SERVER_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${APP_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${MODEL_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${CHROMADBImage}
 
 RUN podman system reset --force 2>/dev/null

--- a/recipes/natural_language_processing/summarizer/bootc/Containerfile
+++ b/recipes/natural_language_processing/summarizer/bootc/Containerfile
@@ -17,6 +17,7 @@ ARG RECIPE=summarizer
 ARG MODEL_IMAGE=quay.io/ai-lab/mistral-7b-instruct:latest
 ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp-python:latest
+ARG TARGETARCH
 
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
@@ -37,8 +38,9 @@ VOLUME /var/lib/containers
 # Prepull the model, model_server & application images to populate the system.
 # Comment the pull commands to keep bootc image smaller.
 # The quadlet .image file added above pulls following images with service startup
-RUN podman pull --root /usr/lib/containers/storage ${SERVER_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${APP_IMAGE}
-RUN podman pull --root /usr/lib/containers/storage ${MODEL_IMAGE}
+
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${SERVER_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${APP_IMAGE}
+RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${MODEL_IMAGE}
 
 RUN podman system reset --force 2>/dev/null


### PR DESCRIPTION
If user overrides the arch of the image, then the podman pull lines in the bootc container need to follow the TARGETARCH and pull the correct image.