### PR TITLE
Fixup download-models

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,3 @@ For example, learn how to run the [chatbot recipe here](./recipes/natural_langua
 Images for many sample applications and models are available in `quay.io`. All
 currently built images are  tracked in
 [ai-lab-recipes-images.md](./ai-lab-recipes-images.md)
-

--- a/model_servers/whispercpp/Makefile
+++ b/model_servers/whispercpp/Makefile
@@ -17,4 +17,4 @@ all: build download-model-whisper-small run
 .PHONY: download-model-whisper-small # small .bin model type testing
 download-model-whisper-small:
 	cd ../../models && \
-	make MODEL_NAME=ggml-small.bin MODEL_URL=https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin -f Makefile download-model
+	make download-model-whisper-small

--- a/models/Containerfile
+++ b/models/Containerfile
@@ -1,4 +1,6 @@
 # Suggested alternative open AI Models
+# 	    https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf
+#	    https://huggingface.co/instructlab/merlinite-7b-lab-GGUF/resolve/main/merlinite-7b-lab-Q4_K_M.gguf
 # 	    https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q5_K_S.gguf
 #	    https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf (Default)
 #	    https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf

--- a/models/Makefile
+++ b/models/Makefile
@@ -24,3 +24,11 @@ download-model-granite:
 .PHONY: download-model-merlinite
 download-model-merlinite:
 	$(MAKE) MODEL_URL=https://huggingface.co/instructlab/merlinite-7b-lab-GGUF/resolve/main/merlinite-7b-lab-Q4_K_M.gguf MODEL_NAME=merlinite-7b-lab-Q4_K_M.gguf download-model
+
+.PHONY: download-model-whisper-small # small .bin model type testing
+download-model-whisper-small:
+	$(MAKE) MODEL_NAME=ggml-small.bin MODEL_URL=https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin download-model
+
+.PHONY: download-model-mistral
+download-model-mistral:
+	$(MAKE) MODEL_NAME=mistral-7b-instruct-v0.1.Q4_K_M.gguf MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf download-model

--- a/models/README.md
+++ b/models/README.md
@@ -5,15 +5,14 @@ The models directory stores models and provides automation around downloading mo
 Want to try one of our tested models? Try or or all of the following:
 
 ```bash
-make -f Makefile download-model-llama
-make -f Makefile download-model-tiny-llama
-make -f Makefile download-model-mistral
-make -f Makefile download-model-whisper-small
-make -f Makefile download-model-whisper-base
+make download-model-granite
+make download-model-merlinite
+make download-model-mistral
+make download-model-whisper-small
 ```
 
 Want to download and run a model you dont see listed? This is supported with the `MODEL_NAME` and `MODEL_URL` params:
 
 ```bash
-make -f Makefile download-model MODEL_URL=https://huggingface.co/andrewcanis/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q4_K_S.gguf MODEL_NAME=c4ai-command-r-v01-Q4_K_S.gguf
+make download-model MODEL_URL=https://huggingface.co/andrewcanis/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q4_K_S.gguf MODEL_NAME=c4ai-command-r-v01-Q4_K_S.gguf
 ```

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -64,11 +64,6 @@ MISTRAL_MODEL_URL := https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GG
 
 MODEL_NAME ?= $(MISTRAL_MODEL_NAME)
 
-.PHONY: download-model-mistral
-download-model-mistral:
-	cd ../../../models && \
-	make MODEL_NAME=mistral-7b-instruct-v0.1.Q4_K_M.gguf MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf -f  Makefile download-model
-
 .PHONY: install
 install::
 	$(MAKE) install-chromedriver RECIPE_BINARIES_PATH=${RECIPE_BINARIES_PATH}


### PR DESCRIPTION
The models/README.md described a bunch of download-model flags
that did not exist or were defined in different makefiles. This
PR removes the non-existing targets and adds the defined targets
into the models/Makefile and referenced from the others.