### PR TITLE
fix convert_models build with build path permissions (temporary)

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -4,6 +4,19 @@ on:
   schedule: # schedule the job to run at 12 AM daily
    - cron: '0 0 * * *'
   
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ./convert_models/**
+      - .github/workflows/model_image_build_push.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - ./convert_models/**
+      - .github/workflows/model_image_build_push.yaml
+
   workflow_dispatch:
 
 env:

--- a/convert_models/Containerfile
+++ b/convert_models/Containerfile
@@ -1,7 +1,10 @@
 FROM registry.access.redhat.com/ubi9/python-311:1-52.1712567218
+USER 0
+RUN mkdir /converter
 WORKDIR /converter
 RUN git clone https://github.com/ggerganov/llama.cpp.git
 RUN cd llama.cpp/ && make
+USER 1001
 RUN pip install -r llama.cpp/requirements.txt
 COPY . /converter/
 ENTRYPOINT ["sh", "run.sh"]


### PR DESCRIPTION
/cc @sallyom @MichaelClifford this was currently breaking the push model image workflow