### PR TITLE
temporarily remove model-converter image build

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -8,20 +8,17 @@ on:
     branches:
       - main
     paths:
-      - ./convert_models/**
       - .github/workflows/model_image_build_push.yaml
   push:
     branches:
       - main
     paths:
-      - ./convert_models/**
       - .github/workflows/model_image_build_push.yaml
 
   workflow_dispatch:
 
 env:
   REGISTRY: quay.io/ai-lab
-  MODEL_CONVERTER_IMAGE_NAME: model-converter
   MERLINITE_MODEL_IMAGE_NAME: merlinite-7b-lab
   MERLINITE_LABEL: Q4_K_M
   MERLINITE_MODEL_URL: https://huggingface.co/instructlab/merlinite-7b-lab-GGUF/resolve/main/merlinite-7b-lab-Q4_K_M.gguf
@@ -33,53 +30,6 @@ env:
   GRANITE_MODEL_URL: https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf
 
 jobs:
-  build-and-push-model-converter-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      # recover disk space
-      - name: Remove unnecessary files
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-      - uses: actions/checkout@v4.1.1
-
-      # required for multi-arch builds
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-
-      - name: Build model-converter image
-        id: build_convert_models_image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.MODEL_CONVERTER_IMAGE_NAME }}
-          tags: latest
-          platforms: linux/amd64, linux/arm64
-          context: convert_models
-          containerfiles: ./convert_models/Containerfile
-
-      - name: Login to quay.io
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Push model-converter image
-        id: push_convert_models_image
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          image: ${{ steps.build_convert_models_image.outputs.image }}
-          tags: ${{ steps.build_convert_models_image.outputs.tags }}
-
   build-and-push-granite-model-image:
     if: contains( github.event.pull_request.labels.*.name, 'hold-tests')
     runs-on: ubuntu-latest


### PR DESCRIPTION
There's an issue with the model_converter image job that is blocking the model image builds. @Gregory-Pereira is going to add this image back in with his refactor PR 🙇 #308 