### PR TITLE
fix typo in model image names on push

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -81,7 +81,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: redhat-actions/push-to-registry@v2
         with:
-          registry: ${{ env.REGISTRY }}
           image: ${{ steps.build_mistral_code_model_image.outputs.image }}
           tags: ${{ steps.build_mistral_code_model_image.outputs.tags }}
 
@@ -133,7 +132,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: redhat-actions/push-to-registry@v2
         with:
-          registry: ${{ env.REGISTRY }}
           image: ${{ steps.build_granite_model_image.outputs.image }}
           tags: ${{ steps.build_granite_model_image.outputs.tags }}
 
@@ -185,7 +183,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: redhat-actions/push-to-registry@v2
         with:
-          registry: ${{ env.REGISTRY }}
           image: ${{ steps.build_merlinite_model_image.outputs.image }}
           tags: ${{ steps.build_merlinite_model_image.outputs.tags }}
 
@@ -237,6 +234,5 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: redhat-actions/push-to-registry@v2
         with:
-          registry: ${{ env.REGISTRY }}
           image: ${{ steps.build_mistral_model_image.outputs.image }}
           tags: ${{ steps.build_mistral_model_image.outputs.tags }}


### PR DESCRIPTION
images are being built with the correct name, but pushed as `quay.io/ai-lab/quay.io/ai-lab/image-name` - this fixes it