### PR TITLE
Update model download example in models README.md

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -2,7 +2,7 @@
 
 The models directory stores models and provides automation around downloading models.
 
-Want to try one of our tested models? Try or or all of the following:
+Want to try one of our tested models? Try one or all of the following:
 
 ```bash
 make download-model-granite
@@ -11,8 +11,8 @@ make download-model-mistral
 make download-model-whisper-small
 ```
 
-Want to download and run a model you dont see listed? This is supported with the `MODEL_NAME` and `MODEL_URL` params:
+Want to download and run a model you don't see listed? This is supported with the `MODEL_NAME` and `MODEL_URL` params:
 
 ```bash
-make download-model MODEL_URL=https://huggingface.co/andrewcanis/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q4_K_S.gguf MODEL_NAME=c4ai-command-r-v01-Q4_K_S.gguf
+make download-model MODEL_URL=https://huggingface.co/TheBloke/openchat-3.5-0106-GGUF/resolve/main/openchat-3.5-0106.Q4_K_M.gguf MODEL_NAME=openchat-3.5-0106.Q4_K_M.gguf
 ```


### PR DESCRIPTION
Download example was referencing a model that does not have an Apache or MIT licenses. Changed for one that does.  