### PR TITLE
quay defaults x86_64 arch to amd64

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -36,6 +36,8 @@ CHROME_DOWNLOAD_PATH ?=
 
 OS := $(shell uname -s)
 ARCH := $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	ARCH := amd64
 
 ifeq ($(OS),Darwin) # This structure may vary if we upgrade chromedriver, see index: https://chromedriver.storage.googleapis.com/index.html
 	ifeq ($(ARCH),amd64)


### PR DESCRIPTION
Attempting to resolve issue: https://github.com/containers-mirror/ai-lab-recipes/actions/runs/8802778394/job/24159340863#step:3:43

Theory, `stream9` tag does not have `x86_64` arch target, only `amd64`, see [`stream9` tag manifests](https://quay.io/repository/centos-bootc/centos-bootc/manifest/sha256:e21db74f33ddc871e5947dfc5ea5fb79bfd9325bea2a97965606cf468eb54b8f)