### PR TITLE
Accelerated container image for NVidia

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -1,13 +1,12 @@
-FROM ?= "quay.io/centos-bootc/centos-bootc:stream9"
+default: help
 
-REGISTRY ?= quay.io
-REGISTRY_ORG ?= ai-lab
-IMAGE_NAME ?= amd
-IMAGE_TAG ?= latest
+help:
+	@echo "Please choose one of the following targets:"
+	@echo "  - amd"
+	@echo "  - nvidia"
 
-CONTAINER_TOOL ?= podman
-CONTAINER_TOOL_EXTRA_ARGS ?=
-
-.PHONY: amd
+.PHONY: amd nvidia
 amd:
 	make -C amd/ image
+nvidia:
+	make -C nvidia/ dtk image

--- a/training/README.md
+++ b/training/README.md
@@ -5,9 +5,10 @@ In order to run accelerated AI workloads, we've prepared [bootc](https://github.
 
 # Makefile targets
 
-| Target     | Description                                |
-|------------|--------------------------------------------|
-| amd        | Create bootable container for AMD platform |
+| Target     | Description                                   |
+|------------|-----------------------------------------------|
+| amd        | Create bootable container for AMD platform    |
+| nvidia     | Create bootable container for NVidia platform |
 
 # Makefile variables
 
@@ -25,5 +26,3 @@ In order to run accelerated AI workloads, we've prepared [bootc](https://github.
 ```
 make amd FROM=registry.redhat.io/rhel9-beta/rhel-bootc:9.4
 ```
-
-

--- a/training/nvidia/Containerfile
+++ b/training/nvidia/Containerfile
@@ -1,0 +1,126 @@
+ARG DRIVER_TOOLKIT_IMAGE="quay.io/ai-lab/nvidia-builder:latest"
+ARG BASEIMAGE="quay.io/centos-bootc/centos-bootc:stream9"
+
+FROM ${DRIVER_TOOLKIT_IMAGE} as builder
+
+ARG BASE_URL='https://us.download.nvidia.com/tesla'
+
+ARG CENTOS_VERSION_MAJOR=''
+ARG KERNEL_VERSION=''
+
+ARG BUILD_ARCH=''
+ARG TARGET_ARCH=''
+
+ARG DRIVER_VERSION='550.54.15'
+
+USER builder
+
+WORKDIR /home/builder
+COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
+
+RUN if [ "${KERNEL_VERSION}" == "" ]; then \
+        RELEASE=$(dnf info kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
+    fi \
+    && if [ "${CENTOS_VERSION_MAJOR}" == "" ]; then \
+        . /etc/os-release \
+        && export CENTOS_VERSION_MAJOR="${VERSION}" ;\
+       fi \
+    && if [ "${BUILD_ARCH}" == "" ]; then \
+        export BUILD_ARCH=$(arch) \
+        && export TARGET_ARCH=$(echo "${BUILD_ARCH}" | sed 's/+64k//') ;\
+        fi \
+    && export KVER=$(echo ${KERNEL_VERSION} | cut -d '-' -f 1) \
+        KREL=$(echo ${KERNEL_VERSION} | cut -d '-' -f 2 | sed 's/\.el._*.*\..\+$//' | cut -d'.' -f 1) \
+        KDIST="."$(echo ${KERNEL_VERSION} | cut -d '-' -f 2 | sed 's/^.*\(\.el._*.*\)\..\+$/\1/' | cut -d'.' -f 2) \
+        DRIVER_STREAM=$(echo ${DRIVER_VERSION} | cut -d '.' -f 1) \
+    && git clone --depth 1 --single-branch -b rhel${CENTOS_VERSION_MAJOR} https://github.com/NVIDIA/yum-packaging-precompiled-kmod \
+    && cd yum-packaging-precompiled-kmod \
+    && mkdir BUILD BUILDROOT RPMS SRPMS SOURCES SPECS \
+    && mkdir nvidia-kmod-${DRIVER_VERSION}-${BUILD_ARCH} \
+    && curl -sLOf ${BASE_URL}/${DRIVER_VERSION}/NVIDIA-Linux-${TARGET_ARCH}-${DRIVER_VERSION}.run \
+    && sh ./NVIDIA-Linux-${TARGET_ARCH}-${DRIVER_VERSION}.run --extract-only --target tmp \
+    && mv tmp/kernel-open nvidia-kmod-${DRIVER_VERSION}-${BUILD_ARCH}/kernel \
+    && tar -cJf SOURCES/nvidia-kmod-${DRIVER_VERSION}-${BUILD_ARCH}.tar.xz nvidia-kmod-${DRIVER_VERSION}-${BUILD_ARCH} \
+    && mv kmod-nvidia.spec SPECS/ \
+    && openssl req -x509 -new -nodes -utf8 -sha256 -days 36500 -batch \
+      -config ${HOME}/x509-configuration.ini \
+      -outform DER -out SOURCES/public_key.der \
+      -keyout SOURCES/private_key.priv \
+    && rpmbuild \
+        --define "% _arch ${BUILD_ARCH}" \
+        --define "%_topdir $(pwd)" \
+        --define "debug_package %{nil}" \
+        --define "kernel ${KVER}" \
+        --define "kernel_release ${KREL}" \
+        --define "kernel_dist ${KDIST}" \
+        --define "driver ${DRIVER_VERSION}" \
+        --define "driver_branch ${DRIVER_STREAM}" \
+        -v -bb SPECS/kmod-nvidia.spec
+
+
+FROM ${BASEIMAGE}
+
+ARG BASE_URL='https://us.download.nvidia.com/tesla'
+
+ARG CENTOS_VERSION_MAJOR=''
+ARG KERNEL_VERSION=''
+
+
+ARG DRIVER_TYPE=passthrough
+ENV NVIDIA_DRIVER_TYPE=${DRIVER_TYPE}
+
+ARG DRIVER_VERSION='550.54.15'
+ENV NVIDIA_DRIVER_VERSION=${DRIVER_VERSION}
+ARG CUDA_VERSION='12.3.2'
+
+ARG TARGET_ARCH=''
+ENV TARGETARCH=${TARGET_ARCH}
+
+# Disable vGPU version compability check by default
+ARG DISABLE_VGPU_VERSION_CHECK=true
+ENV DISABLE_VGPU_VERSION_CHECK=$DISABLE_VGPU_VERSION_CHECK
+
+USER root
+
+COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /rpms/
+COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
+
+RUN dnf install -y /rpms/kmod-nvidia-*.rpm
+
+COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
+
+RUN if [ "${TARGET_ARCH}" == "" ]; then \
+        export TARGET_ARCH="$(arch)" ;\
+        fi \
+    && if [ "${CENTOS_VERSION_MAJOR}" == "" ]; then \
+        . /etc/os-release \
+        && export CENTOS_VERSION_MAJOR="${VERSION}" ;\
+       fi \
+    && export DRIVER_STREAM=$(echo ${DRIVER_VERSION} | cut -d '.' -f 1) \
+        CUDA_VERSION_ARRAY=(${CUDA_VERSION//./ }) \
+        CUDA_DASHED_VERSION=${CUDA_VERSION_ARRAY[0]}-${CUDA_VERSION_ARRAY[1]} \
+        CUDA_REPO_ARCH=${TARGET_ARCH} \
+    && if [ "${TARGET_ARCH}" == "aarch64" ]; then CUDA_REPO_ARCH="sbsa"; fi \
+    && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
+    && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel${CENTOS_VERSION_MAJOR}/${CUDA_REPO_ARCH}/cuda-rhel${CENTOS_VERSION_MAJOR}.repo \
+    && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \
+    && dnf install -y \
+        nvidia-driver-cuda-${DRIVER_VERSION} \
+        nvidia-driver-libs-${DRIVER_VERSION} \
+        nvidia-driver-NVML-${DRIVER_VERSION} \
+        cuda-compat-${CUDA_DASHED_VERSION} \
+        cuda-cudart-${CUDA_DASHED_VERSION} \
+        nvidia-persistenced-${DRIVER_VERSION} \
+        nvidia-container-toolkit \
+    && if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$TARGET_ARCH" != "arm64" ]; then \
+        versionArray=(${DRIVER_VERSION//./ }); \
+        DRIVER_BRANCH=${versionArray[0]}; \
+        dnf module enable -y nvidia-driver:${DRIVER_BRANCH} && \
+        dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \
+    fi \
+    && dnf clean all \
+    && ln -s /usr/lib/systemd/system/nvidia-toolkit-firstboot.service /usr/lib/systemd/system/basic.target.wants/nvidia-toolkit-firstboot.service \
+    && echo "blacklist nouveau" > /etc/modprobe.d/blacklist_nouveau.conf
+

--- a/training/nvidia/Containerfile
+++ b/training/nvidia/Containerfile
@@ -25,7 +25,7 @@ RUN if [ "${KERNEL_VERSION}" == "" ]; then \
     fi \
     && if [ "${CENTOS_VERSION_MAJOR}" == "" ]; then \
         . /etc/os-release \
-        && export CENTOS_VERSION_MAJOR="${VERSION}" ;\
+        && export CENTOS_VERSION_MAJOR="$(echo ${VERSION} | cut -d'.' -f 1)" ;\
        fi \
     && if [ "${BUILD_ARCH}" == "" ]; then \
         export BUILD_ARCH=$(arch) \
@@ -96,7 +96,7 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
         fi \
     && if [ "${CENTOS_VERSION_MAJOR}" == "" ]; then \
         . /etc/os-release \
-        && export CENTOS_VERSION_MAJOR="${VERSION}" ;\
+        && export CENTOS_VERSION_MAJOR="$(echo ${VERSION} | cut -d'.' -f 1)" ;\
        fi \
     && export DRIVER_STREAM=$(echo ${DRIVER_VERSION} | cut -d '.' -f 1) \
         CUDA_VERSION_ARRAY=(${CUDA_VERSION//./ }) \

--- a/training/nvidia/Containerfile.builder
+++ b/training/nvidia/Containerfile.builder
@@ -1,0 +1,55 @@
+FROM quay.io/centos/centos:stream9
+
+ARG KERNEL_VERSION=''
+
+USER root
+
+RUN if [ "${KERNEL_VERSION}" == "" ]; then \
+        RELEASE=$(dnf info kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
+        fi \
+    && echo "${KERNEL_VERSION}" \
+    && dnf -y install dnf-plugin-config-manager \
+    && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
+    && dnf -y install \
+        kernel-devel-${KERNEL_VERSION} \
+        kernel-modules-${KERNEL_VERSION} \
+        kernel-modules-extra-${KERNEL_VERSION} \
+    && if [ $(arch) == "x86_64" ]; then \
+        dnf -y --enablerepo=rt install \
+            kernel-rt-devel-${KERNEL_VERSION} \
+            kernel-rt-modules-${KERNEL_VERSION} \
+            kernel-rt-modules-extra-${KERNEL_VERSION}; \
+    fi \
+    && export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core-${KERNEL_VERSION}) \
+    && export GCC_VERSION=$(cat /lib/modules/${INSTALLED_KERNEL}/config | grep -Eo "gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
+    && dnf -y install \
+        binutils \
+        diffutils \
+        elfutils-libelf-devel \
+        jq \
+        kabi-dw kernel-abi-stablelists \
+        keyutils \
+        kmod \
+        gcc-${GCC_VERSION} \
+        git \
+        make \
+        mokutil \
+        openssl \
+        pinentry \
+        rpm-build \
+        xz \
+    && dnf clean all \
+    && useradd -u 1001 -m -s /bin/bash builder
+
+# Last layer for metadata for mapping the driver-toolkit to a specific kernel version
+RUN if [ "${KERNEL_VERSION}" == "" ]; then \
+        export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core); \
+    else \
+        export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core-${KERNEL_VERSION}) ;\
+    fi \
+    && echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\" }" > /etc/driver-toolkit-release.json \
+    && echo -e "KERNEL_VERSION=\"${INSTALLED_KERNEL}\"" > /etc/driver-toolkit-release.sh
+
+USER builder

--- a/training/nvidia/Containerfile.builder
+++ b/training/nvidia/Containerfile.builder
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream9
 
 ARG KERNEL_VERSION=''
+ARG ENABLE_RT=''
 
 USER root
 
@@ -16,7 +17,7 @@ RUN if [ "${KERNEL_VERSION}" == "" ]; then \
         kernel-devel-${KERNEL_VERSION} \
         kernel-modules-${KERNEL_VERSION} \
         kernel-modules-extra-${KERNEL_VERSION} \
-    && if [ $(arch) == "x86_64" ]; then \
+    && if [ "${ENABLE_RT}" ] && [ $(arch) == "x86_64" ]; then \
         dnf -y --enablerepo=rt install \
             kernel-rt-devel-${KERNEL_VERSION} \
             kernel-rt-modules-${KERNEL_VERSION} \

--- a/training/nvidia/Makefile
+++ b/training/nvidia/Makefile
@@ -1,0 +1,18 @@
+FROM ?= "quay.io/centos-bootc/centos-bootc:stream9"
+
+REGISTRY ?= quay.io
+REGISTRY_ORG ?= ai-lab
+IMAGE_NAME ?= nvidia
+IMAGE_TAG ?= latest
+
+CONTAINER_TOOL ?= podman
+CONTAINER_TOOL_EXTRA_ARGS ?=
+
+.PHONY: image
+dtk:
+	"${CONTAINER_TOOL}" build \
+		--file Containerfile.builder \
+		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
+		--from "${FROM}" \
+		${CONTAINER_TOOL_EXTRA_ARGS}
+

--- a/training/nvidia/Makefile
+++ b/training/nvidia/Makefile
@@ -4,15 +4,28 @@ REGISTRY ?= quay.io
 REGISTRY_ORG ?= ai-lab
 IMAGE_NAME ?= nvidia
 IMAGE_TAG ?= latest
+DTK_IMAGE_NAME ?= nvidia-builder
+DTK_IMAGE_TAG ?= latest
 
 CONTAINER_TOOL ?= podman
 CONTAINER_TOOL_EXTRA_ARGS ?=
 
-.PHONY: image
+DRIVER_VERSION ?= 550.54.15
+CUDA_VERSION ?= 12.3.2
+
+.PHONY: image dtk
 dtk:
 	"${CONTAINER_TOOL}" build \
 		--file Containerfile.builder \
-		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
+		--tag "${REGISTRY}/${REGISTRY_ORG}/${DTK_IMAGE_NAME}:${DTK_IMAGE_TAG}" \
 		--from "${FROM}" \
 		${CONTAINER_TOOL_EXTRA_ARGS}
-
+image:
+	"${CONTAINER_TOOL}" build \
+		--file Containerfile \
+		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
+		--build-arg BASEIMAGE="${FROM}" \
+		--build-arg DRIVER_TOOLKIT_IMAGE="${REGISTRY}/${REGISTRY_ORG}/${DTK_IMAGE_NAME}:${DTK_IMAGE_TAG}" \
+		--build-arg DRIVER_VERSION="${DRIVER_VERSION}" \
+		--build-arg CUDA_VERSION="${CUDA_VERSION}" \
+		${CONTAINER_TOOL_EXTRA_ARGS}

--- a/training/nvidia/nvidia-toolkit-firstboot.service
+++ b/training/nvidia/nvidia-toolkit-firstboot.service
@@ -1,0 +1,13 @@
+[Unit]
+# For more information see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html
+# It looks like the podman/CDI integration wants a pre-generated list of hardware
+Description=Generate /etc/cdi/nvidia.yaml
+
+[Service]
+Type=oneshot
+ExecStart=nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+RemainAfterExit=yes
+
+[Install]
+# TODO: Ensure we have a target that is like "container setup"
+WantedBy=multi-user.target

--- a/training/nvidia/x509-configuration.ini
+++ b/training/nvidia/x509-configuration.ini
@@ -1,0 +1,15 @@
+[ req ]
+default_bits = 4096
+distinguished_name = req_distinguished_name
+prompt = no
+string_mask = utf8only
+x509_extensions = myexts
+[ req_distinguished_name ]
+O = Project Magma
+CN = Project Magma
+emailAddress = magma@acme.com
+[ myexts ]
+basicConstraints=critical,CA:FALSE
+keyUsage=digitalSignature
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid


### PR DESCRIPTION
This work has been mostly done by @fabiendupont at https://github.com/fabiendupont/driver-toolkit and https://github.com/fabiendupont/centos-bootc-nvidia. This PR brings it in ai-lab-recipes with dual base image support (CentOS and Red Hat) and simplified settings.