### PR TITLE
Better separation between CentOS and RHEL

### DIFF
--- a/training/amd/Containerfile
+++ b/training/amd/Containerfile
@@ -2,5 +2,15 @@ FROM quay.io/centos-bootc/centos-bootc:stream9
 
 ADD rocm.repo /etc/yum.repos.d/rocm.repo
 
-RUN curl -L https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -o /tmp/epel-release-latest-9.noarch.rpm && rpm -ivh /tmp/epel-release-latest-9.noarch.rpm && rm -f /tmp/epel-release-latest-9.noarch.rpm
-RUN dnf install -y 'dnf-command(config-manager)' && crb enable && dnf install -y rocm && dnf clean all
+# Enable CRB repo for CentOS. For RHEL, it should be enabled on the build host
+RUN source /etc/os-release \
+    && export OS_ID="$ID" \
+    && if [ "$OS_ID" == "centos" ]; then \
+        curl -L https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm -o /tmp/epel-release-latest-9.noarch.rpm \
+        && rpm -ivh /tmp/epel-release-latest-9.noarch.rpm \
+        && rm -f /tmp/epel-release-latest-9.noarch.rpm \
+        && dnf install -y 'dnf-command(config-manager)' \
+        && crb enable ;\
+    fi
+
+RUN dnf install -y rocm && dnf clean all


### PR DESCRIPTION
I've made a selector based on /etc/os-release for enabling CRB repo for CentOS. For RHEL, the CRB repo should be enabled on the build host.