### PR TITLE
Get exact token count in summarizer

### DIFF
--- a/recipes/natural_language_processing/summarizer/app/requirements.txt
+++ b/recipes/natural_language_processing/summarizer/app/requirements.txt
@@ -1,4 +1,4 @@
 langchain
 langchain_openai
 streamlit
-pypdf
+pymupdf


### PR DESCRIPTION
This PR uses the `/extras/tokenize/` and `extras/detokenize/` methods of the llamacpp_python api server while chunking the text to get the exact number of tokens that will be used in each prompt. This is an improvement over the earlier method where we were simply estimating the token count. Estimation is imperfect, it worked in many cases, but could cause errors if the documents contained a lot of rarer tokens (particularly noted in PDF docs). 

I've also swapped the PDF reader package from `pypdf` to `pymupdf` which overcame some PDF decoding issues that came up while adding the new chunking text method.