### PR TITLE
[Model Upgrade] swapping `whisper-small` with `whisper-large-v3-q5_0`

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -43,6 +43,10 @@ jobs:
             label: Q4_K_M
             url: https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf
             platforms: linux/amd64,linux/arm64
+          - image_name: whisper-large
+            label: v3_Q5_0
+            url: https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin
+            platform: linux/amd64,linux/arm64
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/ailab-images.md
+++ b/ailab-images.md
@@ -17,3 +17,5 @@
     - [model download link](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf)
 - quay.io/ai-lab/codellama-7b:latest
     - [model download link](https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf) 
+- quay.io/ai-lab/whisper-large:latest
+    - [model download link](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin)

--- a/model_servers/whispercpp/Makefile
+++ b/model_servers/whispercpp/Makefile
@@ -9,12 +9,12 @@ IMAGE ?= $(REGISTRY)/$(IMAGE_NAME)
 # VULKAN_IMAGE := $(REGISTRY)/$(BASE_IMAGE_NAME)/$(APP)_vulkan:latest
 
 MODELS_PATH := /app/models
-MODEL_NAME ?= ggml-small.bin
+MODEL_NAME ?= ggml-large-v3-q5_0.bin
 
 .PHONY: all
-all: build download-model-whisper-small run
+all: build download-model-whisper-large run
 
-.PHONY: download-model-whisper-small # small .bin model type testing
-download-model-whisper-small:
+.PHONY: download-model-whisper-large
+download-model-whisper-large:
 	cd ../../models && \
-	make download-model-whisper-small
+	make download-model-whisper-large

--- a/model_servers/whispercpp/README.md
+++ b/model_servers/whispercpp/README.md
@@ -19,13 +19,16 @@ make -f Makefile build
 ### Download Whisper model
 
 You can to download the model from HuggingFace. There are various Whisper models available which vary in size and can be found
-[here](https://huggingface.co/ggerganov/whisper.cpp). We will be using the `small` model which is about 466 MB.
+[here](https://huggingface.co/ggerganov/whisper.cpp). We will be using the `large` 5-bit quanitzed model which is about 1.08 GB.
 
-- **small**
-    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin)
+- **large-v3-q5_0**
+    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin)
+
+- **large-v3-q5_0.en**
+    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.en.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.en.bin)
 
 - **base.en**
-    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin)
+    - Download URL: [https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin](https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin)
 
 ```bash
 cd ../../models
@@ -36,16 +39,16 @@ cd ../model_servers/whispercpp
 ### Deploy Model Service
 
 Deploy the LLM and volume mount the model of choice.
-Here, we are mounting the `ggml-small.bin` model as downloaded from above.
+Here, we are mounting the `ggml-large-v3-q5_0.bin` model as downloaded from above.
 
 ```bash
 # Note: the :Z may need to be omitted from the model volume mount if not running on Linux
 
 podman run --rm -it \
         -p 8001:8001 \
-        -v /local/path/to/locallm/models/ggml-small.bin:/models/ggml-small.bin:Z,ro \
+        -v /local/path/to/locallm/models/ggml-large-v3-q5_0.bin:/models/ggml-large-v3-q5_0.bin:Z,ro \
         -e HOST=0.0.0.0 \
-        -e MODEL_PATH=/models/ggml-small.bin \
+        -e MODEL_PATH=/models/ggml-large-v3-q5_0.bin \
         -e PORT=8001 \
         whisper:image
 ```

--- a/model_servers/whispercpp/tests/conftest.py
+++ b/model_servers/whispercpp/tests/conftest.py
@@ -12,7 +12,7 @@ else:
     IMAGE_NAME = os.environ['IMAGE_NAME']
 
 if not 'MODEL_NAME' in os.environ:
-    MODEL_NAME = 'ggml-small.bin'
+    MODEL_NAME = 'ggml-large-v3-q5_0.bin'
 else: 
     MODEL_NAME = os.environ['MODEL_NAME']
 

--- a/models/Makefile
+++ b/models/Makefile
@@ -25,9 +25,9 @@ download-model-granite:
 download-model-merlinite:
 	$(MAKE) MODEL_URL=https://huggingface.co/instructlab/merlinite-7b-lab-GGUF/resolve/main/merlinite-7b-lab-Q4_K_M.gguf MODEL_NAME=merlinite-7b-lab-Q4_K_M.gguf download-model
 
-.PHONY: download-model-whisper-small # small .bin model type testing
-download-model-whisper-small:
-	$(MAKE) MODEL_NAME=ggml-small.bin MODEL_URL=https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin download-model
+.PHONY: download-model-whisper-large
+download-model-whisper-large:
+	$(MAKE) MODEL_NAME=ggml-large-v3-q5_0.bin MODEL_URL=https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin download-model
 
 .PHONY: download-model-mistral
 download-model-mistral:

--- a/models/README.md
+++ b/models/README.md
@@ -8,7 +8,7 @@ Want to try one of our tested models? Try one or all of the following:
 make download-model-granite
 make download-model-merlinite
 make download-model-mistral
-make download-model-whisper-small
+make download-model-whisper-large
 ```
 
 Want to download and run a model you don't see listed? This is supported with the `MODEL_NAME` and `MODEL_URL` params:

--- a/recipes/audio/audio_to_text/README.md
+++ b/recipes/audio/audio_to_text/README.md
@@ -30,13 +30,13 @@ The rest of this document will explain how to build and run the application from
 If you are just getting started, we recommend using [ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp).
 This is a well performant model with an MIT license.
 It's simple to download a pre-converted whisper model from [huggingface.co](https://huggingface.co)
-here: https://huggingface.co/ggerganov/whisper.cpp. There are a number of options, but we recommend to start with `ggml-small.bin`.
+here: https://huggingface.co/ggerganov/whisper.cpp. There are a number of options, but we recommend to start with `ggml-large-v3-q5_0.bin`.
 
 The recommended model can be downloaded using the code snippet below:
 
 ```bash
 cd ../../../models
-curl -sLO https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+curl -sLO https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin
 cd ../recipes/audio/audio_to_text
 ```
 

--- a/recipes/audio/audio_to_text/quadlet/audio-to-text.yaml
+++ b/recipes/audio/audio_to_text/quadlet/audio-to-text.yaml
@@ -8,7 +8,7 @@ spec:
   initContainers:
   - name: model-file
     image: MODEL_IMAGE
-    command: ['/usr/bin/install', "/model/ggml-small.bin", "/shared/"]
+    command: ['/usr/bin/install', "/model/ggml-large-v3-q5_0.bin", "/shared/"]
     volumeMounts:
     - name: model-file
       mountPath: /shared


### PR DESCRIPTION
When perusing the [ggerganov whisper.cpp model repo](https://huggingface.co/ggerganov/whisper.cpp/tree/main) we use, I realize that we use this compared to the upstream [OpenAI whisper small repo](https://huggingface.co/openai/whisper-small) there were 2 reasons to use this repo: the `.gguf` format for compatibility with the `llamacpp_python` model_server as well as quantization. However we are not taking advantage of the quantization. This is the only model for which we don't use quantization, so I thought I would fix this.

I selected the `large-v3` model quantized at 5-bits because the footprint of our whisper model was also far below that of our other standard examples of Mistral and Granite. This model size change brings the footprint:

- From:
    - storage: `488 MB`
    - memory: `~1.0 GB`
- To: 
    - storage: `1.08 GB`
    - memory:  `~4.7 GB`

To put this in perspective of our other standard models:

- [mistral-7b-instruct-v0.1.Q4_K_M.gguf](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/blob/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf)
    - storage: `4.37 GB`
    - memory: `6.87 GB`
- [granite-7b-lab](https://huggingface.co/instructlab/granite-7b-lab)
    - storage: `3.8 GB`
    - No memory usage info available on model card

@MichaelClifford 