### PR TITLE
[Model Upgrade] upgrade `mistral-7b-instruct-v0.1` to `mistral-7b-instruct-v0.2`

### DIFF
--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -33,7 +33,7 @@ jobs:
             platforms: linux/amd64,linux/arm64
           - image_name: mistral-7b-instruct
             label: Q4_K_M
-            url: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf
+            url: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf
             platforms: linux/amd64,linux/arm64
           - image_name: merlinite-7b-lab
             label: Q4_K_M

--- a/ailab-images.md
+++ b/ailab-images.md
@@ -14,6 +14,6 @@
 ## Model Images (x86_64, aarch64)
 
 - quay.io/ai-lab/mistral-7b-instruct:latest
-    - [model download link](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf)
+    - [model download link](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf)
 - quay.io/ai-lab/codellama-7b:latest
     - [model download link](https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf) 

--- a/model_servers/llamacpp_python/tests/conftest.py
+++ b/model_servers/llamacpp_python/tests/conftest.py
@@ -13,7 +13,7 @@ else:
     IMAGE_NAME = os.environ['IMAGE_NAME']
 
 if not 'MODEL_NAME' in os.environ:
-    MODEL_NAME = 'mistral-7b-instruct-v0.1.Q4_K_M.gguf'
+    MODEL_NAME = 'mistral-7b-instruct-v0.2.Q4_K_M.gguf'
 else: 
     MODEL_NAME = os.environ['MODEL_NAME']
 

--- a/model_servers/llamacpp_python/tooling_options.ipynb
+++ b/model_servers/llamacpp_python/tooling_options.ipynb
@@ -23,7 +23,7 @@
     "This notebook assumes that the playground image is running locally. Once built, you can use the below to start the model service image. \n",
     "\n",
     "```bash\n",
-    "podman run -it -p 8000:8000 -v <YOUR-LOCAL-PATH>/locallm/models:/locallm/models:Z -e MODEL_PATH=models/mistral-7b-instruct-v0.1.Q4_K_M.gguf playground\n",
+    "podman run -it -p 8000:8000 -v <YOUR-LOCAL-PATH>/locallm/models:/locallm/models:Z -e MODEL_PATH=models/mistral-7b-instruct-v0.2.Q4_K_M.gguf playground\n",
     "```"
    ]
   },

--- a/models/Containerfile
+++ b/models/Containerfile
@@ -2,7 +2,7 @@
 # 	    https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf
 #	    https://huggingface.co/instructlab/merlinite-7b-lab-GGUF/resolve/main/merlinite-7b-lab-Q4_K_M.gguf
 # 	    https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q5_K_S.gguf
-#	    https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf (Default)
+#	    https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf (Default)
 #	    https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf
 #	    https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
 # podman build --build-arg="MODEL_URL=https://..." -t quay.io/yourimage .

--- a/models/Makefile
+++ b/models/Makefile
@@ -31,7 +31,7 @@ download-model-whisper-small:
 
 .PHONY: download-model-mistral
 download-model-mistral:
-	$(MAKE) MODEL_NAME=mistral-7b-instruct-v0.1.Q4_K_M.gguf MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf download-model
+	$(MAKE) MODEL_NAME=mistral-7b-instruct-v0.2.Q4_K_M.gguf MODEL_URL=https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf download-model
 
 .PHONY: clean
 clean:

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -62,8 +62,8 @@ UNZIP_EXISTS ?= $(shell command -v unzip)
 RELATIVE_MODELS_PATH := ?=
 RELATIVE_TESTS_PATH := ?=
 
-MISTRAL_MODEL_NAME := mistral-7b-instruct-v0.1.Q4_K_M.gguf
-MISTRAL_MODEL_URL := https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf
+MISTRAL_MODEL_NAME := mistral-7b-instruct-v0.2.Q4_K_M.gguf
+MISTRAL_MODEL_URL := https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf
 
 MODEL_NAME ?= $(MISTRAL_MODEL_NAME)
 

--- a/recipes/natural_language_processing/rag/README.md
+++ b/recipes/natural_language_processing/rag/README.md
@@ -62,7 +62,7 @@ The recommended model can be downloaded using the code snippet below:
 
 ```bash
 cd models
-wget https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf
+wget https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf
 cd ../
 ```
 


### PR DESCRIPTION
[Model `Mistral-7b-instruct-v0.2`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF) has been released for a while now, we should upgrade anything using this model. I understand that granite is our default but we still provide it as a working model so the version should get bumped.

@MichaelClifford 