### PR TITLE
fix push image step double registry

### DIFF
--- a/.github/workflows/model-converter.yaml
+++ b/.github/workflows/model-converter.yaml
@@ -50,7 +50,7 @@ jobs:
         id: build_image
         uses: redhat-actions/buildah-build@v2.13
         with:
-          image: ${{ env.REGISTRY}}/${{ env.REGISTRY_ORG }}/model-converter
+          image: ${{ env.REGISTRY_ORG }}/model-converter
           platforms: ${{ matrix.platforms }}
           tags: latest
           containerfiles: convert_models/Containerfile


### PR DESCRIPTION
From logs:
```
Combining image name "quay.io/ai-lab/model-converter" and registry "quay.io" to form registry path "quay.io/quay.io/ai-lab/model-converter"
/usr/bin/podman manifest push --quiet --digestfile quay.io-ai-lab-model-converter-latest_digest.txt quay.io/ai-lab/model-converter:latest quay.io/quay.io/ai-lab/model-converter:latest --all --tls-verify=true
Error: writing blob: initiating layer upload to /v2/quay.io/ai-lab/model-converter/blobs/uploads/ in quay.io: name unknown: repository not found
```