### PR TITLE
Add nvidia-instructlab-bootc and supporting materials

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Template values replaced by container build
+TRAIN_DEVICE="__REPLACE_TRAIN_DEVICE__"
+CONTAINER_DEVICE="__REPLACE_CONTAINER_DEVICE__"
+CONTAINER_NAME="__REPLACE_CONTAINER_NAME__"
+
+# HF caching uses relative symlink structures, so keep cache relative to
+# the central working directory
+CONTAINER_CACHE="/instructlab/cache"
+HOST_CACHE="$(pwd)/cache"
+WORKDIR="$(pwd)"
+
+has_argument() {
+	match=$1
+	shift
+	for arg in "$@"; do
+		if [[ "$arg" == *"$match"* ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+mkdir -p "${HOST_CACHE}"
+PODMAN_COMMAND=("podman" "run" "--rm" "-it" "--device" "${CONTAINER_DEVICE}" \
+		"--security-opt" "label=disable" "--net" "host" \
+		"-v" "${WORKDIR}:/instructlab" "--entrypoint" "" \
+		"-e" "HF_HOME=${CONTAINER_CACHE}" \
+		"${CONTAINER_NAME}")
+if [[ "$1" = "init" ]]; then
+	if ! has_argument "--repository" "$@"; then
+		shift
+		"${PODMAN_COMMAND[@]}" ilab init \
+			--repository https://github.com/instructlab/taxonomy.git "$@"
+		exit $?
+	fi
+elif [[ "$1" = "train" ]]; then
+	if ! has_argument "--device" "$@"; then
+		shift
+		"${PODMAN_COMMAND[@]}" ilab train --device ${TRAIN_DEVICE} "$@"
+		exit $?
+	fi
+fi
+
+"${PODMAN_COMMAND[@]}" ilab "$@"
+

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -123,16 +123,38 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
     && ln -s /usr/lib/systemd/system/nvidia-toolkit-firstboot.service /usr/lib/systemd/system/basic.target.wants/nvidia-toolkit-firstboot.service \
     && echo "blacklist nouveau" > /etc/modprobe.d/blacklist_nouveau.conf
 
-ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
+
+ARG SSHPUBKEY
+
+# The --build-arg "SSHPUBKEY=$(cat ~/.ssh/id_rsa.pub)" option inserts your
+# public key into the image, allowing root access via ssh.
+RUN set -eu; mkdir -p /usr/ssh && \
+    echo 'AuthorizedKeysFile /usr/ssh/%u.keys .ssh/authorized_keys .ssh/authorized_keys2' >> /etc/ssh/sshd_config.d/30-auth-system.conf && \
+    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys
 
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
-RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
+# Also make sure not to duplicate if a base image already has it specified.
+RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
+    sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
         /etc/containers/storage.conf
+
+ARG WRAPPER
+COPY ${WRAPPER} /usr/local/bin/ilab
+
+ARG INSTRUCTLAB_IMAGE
+ARG INSTRUCTLAB_IMAGE_ID
+ARG INSTRUCTLAB_IMAGE_SHA
+
+RUN sed -i 's/__REPLACE_TRAIN_DEVICE__/cuda/' /usr/local/bin/ilab
+RUN sed -i 's/__REPLACE_CONTAINER_DEVICE__/nvidia.com\/gpu=all/' /usr/local/bin/ilab
+RUN sed -i "s%__REPLACE_CONTAINER_NAME__%${INSTRUCTLAB_IMAGE}%" /usr/local/bin/ilab
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
 
-# Prepull the instructlab image
+# RUN podman pull --root /usr/lib/containers/storage ${INSTRUCTLAB_IMAGE}
+RUN podman --root /usr/lib/containers/storage load -i /input/image.tar
 
-RUN podman pull --arch=${TARGETARCH} --root /usr/lib/containers/storage ${INSTRUCTLAB_IMAGE}
+RUN podman image tag ${INSTRUCTLAB_IMAGE_ID} ${INSTRUCTLAB_IMAGE}
+RUN podman system reset --force 2>/dev/null

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -18,8 +18,15 @@ KERNEL_VERSION ?=
 ENABLE_RT ?=
 
 ARCH ?=
+SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub 2> /dev/null)
+INSTRUCTLAB_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/instructlab-nvidia:$(IMAGE_TAG)
+INSTRUCTLAB_IMAGE_SHA = sha-$(shell $(CONTAINER_TOOL) image inspect $(INSTRUCTLAB_IMAGE) --format {{.Digest}} | sed 's/^.*://')
+INSTRUCTLAB_IMAGE_ID = $(shell $(CONTAINER_TOOL) image inspect $(INSTRUCTLAB_IMAGE) --format {{.Id}})
+WRAPPER = $(CURDIR)/../ilab-wrapper/ilab
+OUTDIR_REL = out
+OUTDIR = $(CURDIR)/$(OUTDIR_REL)
 
-.PHONY: image dtk
+.PHONY: dtk
 dtk:
 	"${CONTAINER_TOOL}" build \
 		$(ARCH:%=--platform linux/%) \
@@ -30,12 +37,15 @@ dtk:
 		$(FROM:%=--from=%) \
 		${CONTAINER_TOOL_EXTRA_ARGS} \
 		.
-image:
+
+.PHONY: image
+image: check-sshkey prepare-files
 	"${CONTAINER_TOOL}" build \
 		--security-opt label=disable \
 		--cap-add SYS_ADMIN \
 		$(ARCH:%=--platform linux/%) \
 		--file Containerfile \
+		-v ${OUTDIR}:/input \
 		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
 		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(OS_VERSION_MAJOR:%=--build-arg OS_VERSION_MAJOR=%) \
@@ -44,9 +54,36 @@ image:
 		$(DRIVER_VERSION:%=--label driver-version=%) \
 		$(DRIVER_VERSION:%=--build-arg DRIVER_VERSION=%) \
 		$(CUDA_VERSION:%=--build-arg CUDA_VERSION=%) \
+		--build-arg "INSTRUCTLAB_IMAGE=$(INSTRUCTLAB_IMAGE)" \
+		--build-arg "INSTRUCTLAB_IMAGE_SHA=$(INSTRUCTLAB_IMAGE_SHA)" \
+		--build-arg "INSTRUCTLAB_IMAGE_ID=$(INSTRUCTLAB_IMAGE_ID)" \
+		--build-arg "WRAPPER=$(OUTDIR_REL)/ilab" \
+		--build-arg "SSHPUBKEY=$(SSH_PUBKEY)" \
 		${CONTAINER_TOOL_EXTRA_ARGS} \
 		.
 
 .PHONY: push
 push:
 	podman push "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+.PHONY: prepare-files
+prepare-files: $(OUTDIR)/$(WRAPPER) $(OUTDIR)/$(INSTRUCTLAB_IMAGE_SHA)
+
+
+$(OUTDIR):
+	mkdir -p $(OUTDIR)
+
+$(OUTDIR)/$(WRAPPER): $(OUTDIR)
+	cp -f $(WRAPPER) $(OUTDIR)
+
+$(OUTDIR)/$(INSTRUCTLAB_IMAGE_SHA):
+	rm -f $(OUTDIR)/image.tar
+	$(CONTAINER_TOOL) save --format oci-archive -o  $(OUTDIR)/image.tar $(INSTRUCTLAB_IMAGE)
+	echo $(INSTRUCTLAB_IMAGE_ID) > $(OUTDIR)/image-id
+	touch $(OUTDIR)/$(INSTRUCTLAB_IMAGE_SHA)
+
+.PHONY: check-sshkey
+check-sshkey:
+	@test -n "$(SSH_PUBKEY)" || \
+		(echo -n "Error: no ssh key defined! "; \
+		 echo "Create ~/.ssh/id_rsa.pub or set SSH_PUBKEY"; exit 1)


### PR DESCRIPTION
This extends nvidia-bootc:
- Adds the instructlab-nvidia container
- Adds an ilab wrapper script to orchestrate usage of ilab
  + In the near future this will be extended to coordinate the soon to come multi-container mechanism for training but gets us something working now.
- Adds ssh key setup
