### PR TITLE
minor update for `bootc-image-builder` target

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -106,7 +106,12 @@ bootc-run:
 	  $(BOOTC_IMAGE) /sbin/init
 
 .PHONY: bootc-image-builder
-bootc-image-builder: bootc
+bootc-image-builder:
+	@if podman image exists $(BOOTC_IMAGE); then \
+		echo "$(BOOTC_IMAGE) exists in local storage, using it"; \
+	else \
+		$(MAKE) bootc; \
+	fi
 	mkdir -p build/store
 	podman run \
 	  --rm \

--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -10,8 +10,8 @@ SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub;)
 BOOTC_IMAGE ?= quay.io/$(REGISTRY_ORG)/${APP}-bootc:latest
 BOOTC_IMAGE_BUILDER ?= quay.io/centos-bootc/bootc-image-builder
 DISK_TYPE ?= qcow2
-DISK_USER ?= $(shell id -u)
-DISK_GROUP ?= $(shell id -g)
+DISK_UID ?= $(shell id -u)
+DISK_GID ?= $(shell id -g)
 FROM ?=
 ARCH ?=
 CONTAINERFILE ?= Containerfile
@@ -127,7 +127,7 @@ bootc-image-builder:
 	  $(BOOTC_IMAGE_BUILDER) \
 	  $(ARCH:%=--target-arch %) \
 	  --type $(DISK_TYPE) \
-	  --chown $(DISK_USER):$(DISK_GROUP) \
+	  --chown $(DISK_UID):$(DISK_GID) \
 	  --local \
 	  $(BOOTC_IMAGE)
 

--- a/recipes/common/README.md
+++ b/recipes/common/README.md
@@ -28,6 +28,8 @@ used to override defaults for a variety of make targets.
 |BOOTC_IMAGE_BUILDER | Bootc Image Builder container image 	      	    | `quay.io/centos-bootc/bootc-image-builder`	      |
 |CHROMADB_IMAGE      | ChromaDB image to be used for application      	    | `$(REGISTRY)/$(REGISTRY_ORG)/chromadb:latest`	      |
 |DISK_TYPE           | Disk type to be created by BOOTC_IMAGE_BUILDER 	    | `qcow2` (Options: ami, iso, vmdk, raw)		      |
+|DISK_UID            | Disk UID to be specified by BOOTC_IMAGE_BUILDER      | `$(shell id -u)`					      |
+|DISK_GID            | Disk GID to be specified by BOOTC_IMAGE_BUILDER      | `$(shell id -g)`					      |
 |MODEL_IMAGE 	     | AI Model to be used by application             	    | `$(REGISTRY)/$(REGISTRY_ORG)/mistral-7b-instruct:latest`|
 |SERVER_IMAGE 	     | AI Model Server Application                    	    | `$(REGISTRY)/$(REGISTRY_ORG)/llamacpp_python:latest`    |
 |SSH_PUBKEY 	     | SSH Public key preloaded in bootc image.             | `$(shell cat ${HOME}/.ssh/id_rsa.pub;)`		      |


### PR DESCRIPTION
1. `bootc-image-builder` target depends on `bootc`, even the bootc image
exists in the local storage, it still builds a new one. As we add
`--local` in the podman command line, so this commit only check image in
local storage, will not check remote registry.
2. DISK_USER and DISK_GROUP are from #299, they are used for bib option
`--chown`. However, the current variable name may cause
misunderstanding, mislead people into thinking it's a user of operation
system inside disk, so rename them.
Also, add these 2 variables into the README.

Signed-off-by: Yihuang Yu <yihyu@redhat.com>