### PR TITLE
using image name nvidia-bootc for /training/nvidia/Containerfile

### DIFF
--- a/.github/workflows/instructlab_baseimages_build_push.yaml
+++ b/.github/workflows/instructlab_baseimages_build_push.yaml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - image_name: instructlab-nvidia
+          - image_name: nvidia-bootc
             label: driver-version=550.54.15 
             containerfile: training/nvidia/Containerfile
             context: training/nvidia


### PR DESCRIPTION
matches what we see in the makefile: https://github.com/containers/ai-lab-recipes/blob/main/training/nvidia/Makefile#L5