### PR TITLE
refactor instructlab training images to use make targets

### DIFF
--- a/.github/workflows/instructlab_baseimages_build_push.yaml
+++ b/.github/workflows/instructlab_baseimages_build_push.yaml
@@ -28,15 +28,14 @@ env:
   REGISTRY_ORG: ai-lab
 
 jobs:
-  build-and-push-builder-image:
+  nvidia-bootc-builder-image:
     if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
     strategy:
       matrix:
         include:
           - image_name: nvidia-builder
-            containerfile: training/nvidia/Containerfile.builder
-            context: training/nvidia
-            platforms: linux/amd64
+            context: training/nvidia-bootc
+            archs: amd64
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,13 +55,8 @@ jobs:
       
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2.13
-        with:
-          image: ${{ env.REGISTRY_ORG }}/${{ matrix.image_name }}
-          platforms: ${{ matrix.platforms }}
-          tags: latest
-          containerfiles: ${{ matrix.containerfile }}
-          context: ${{ matrix.context }}
+        run: make dtk ARCH=${{ matrix.archs }}
+        working-directory: ${{ matrix.context }}
 
       - name: Login to Container Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -80,17 +74,16 @@ jobs:
           tags: ${{ steps.build_image.outputs.tags }}
           registry: ${{ env.REGISTRY }}
 
-  build-and-push-image:
+  nvidia-bootc-image:
     if: "success() && !contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
     needs: build-and-push-builder-image
     strategy:
       matrix:
         include:
           - image_name: nvidia-bootc
-            label: driver-version=550.54.15 
-            containerfile: training/nvidia/Containerfile
-            context: training/nvidia
-            platforms: linux/amd64
+            driver_version: "550.54.15"
+            context: training/nvidia-bootc
+            archs: amd64
     runs-on: ubuntu-22.04-8-cores
     steps:
       - name: Remove unnecessary files
@@ -102,15 +95,84 @@ jobs:
       
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2.13
+        run: make image DRIVER_VERSION=${{ matrix.driver_version }} ARCH=${{ matrix.archs }}
+        working-directory: ${{ matrix.context }}
+        
+      - name: Login to Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: redhat-actions/podman-login@v1.7
         with:
-          image: ${{ env.REGISTRY_ORG }}/${{ matrix.image_name }}
-          platforms: ${{ matrix.platforms }}
-          labels: |
-            ${{ matrix.label }}
-          tags: latest
-          containerfiles: ${{ matrix.containerfile }}
-          context: ${{ matrix.context }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: redhat-actions/push-to-registry@v2.8
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
+
+  intel-bootc-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
+    strategy:
+      matrix:
+        include:
+          - image_name: intel-gaudi-bootc
+            context: training/intel-bootc
+            archs: amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - uses: actions/checkout@v4.1.1
+      
+      - name: Build Image
+        id: build_image
+        run: make image ARCH=${{ matrix.archs }}
+        working-directory: ${{ matrix.context }}
+
+      - name: Login to Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: redhat-actions/podman-login@v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: redhat-actions/push-to-registry@v2.8
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: ${{ env.REGISTRY }}
+      
+  amd-bootc-image:
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
+    strategy:
+    matrix:
+      include:
+        - image_name: amd-bootc
+          context: training/amd-bootc
+          archs: amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - uses: actions/checkout@v4.1.1
+      
+      - name: Build Image
+        id: build_image
+        run: make image ARCH=${{ matrix.archs }}
+        working-directory: ${{ matrix.context }}
 
       - name: Login to Container Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/instructlab_baseimages_build_push.yaml
+++ b/.github/workflows/instructlab_baseimages_build_push.yaml
@@ -35,7 +35,7 @@ jobs:
         include:
           - image_name: nvidia-builder
             context: training/nvidia-bootc
-            archs: amd64
+            arch: amd64
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,7 +55,7 @@ jobs:
       
       - name: Build Image
         id: build_image
-        run: make dtk ARCH=${{ matrix.archs }}
+        run: make dtk ARCH=${{ matrix.arch }}
         working-directory: ${{ matrix.context }}
 
       - name: Login to Container Registry
@@ -76,14 +76,14 @@ jobs:
 
   nvidia-bootc-image:
     if: "success() && !contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
-    needs: build-and-push-builder-image
+    needs: nvidia-bootc-builder-image
     strategy:
       matrix:
         include:
           - image_name: nvidia-bootc
             driver_version: "550.54.15"
             context: training/nvidia-bootc
-            archs: amd64
+            arch: amd64
     runs-on: ubuntu-22.04-8-cores
     steps:
       - name: Remove unnecessary files
@@ -95,7 +95,7 @@ jobs:
       
       - name: Build Image
         id: build_image
-        run: make image DRIVER_VERSION=${{ matrix.driver_version }} ARCH=${{ matrix.archs }}
+        run: make image DRIVER_VERSION=${{ matrix.driver_version }} ARCH=${{ matrix.arch }}
         working-directory: ${{ matrix.context }}
         
       - name: Login to Container Registry
@@ -121,7 +121,10 @@ jobs:
         include:
           - image_name: intel-gaudi-bootc
             context: training/intel-bootc
-            archs: amd64
+            arch: amd64
+          - image_name: amd-bootc
+            context: training/amd-bootc
+            arch: amd64
     runs-on: ubuntu-latest
     steps:
       - name: Remove unnecessary files
@@ -133,45 +136,7 @@ jobs:
       
       - name: Build Image
         id: build_image
-        run: make image ARCH=${{ matrix.archs }}
-        working-directory: ${{ matrix.context }}
-
-      - name: Login to Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: redhat-actions/podman-login@v1.7
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Push image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: redhat-actions/push-to-registry@v2.8
-        with:
-          image: ${{ steps.build_image.outputs.image }}
-          tags: ${{ steps.build_image.outputs.tags }}
-          registry: ${{ env.REGISTRY }}
-      
-  amd-bootc-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers-mirror/ai-lab-recipes'"
-    strategy:
-    matrix:
-      include:
-        - image_name: amd-bootc
-          context: training/amd-bootc
-          archs: amd64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove unnecessary files
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-      - uses: actions/checkout@v4.1.1
-      
-      - name: Build Image
-        id: build_image
-        run: make image ARCH=${{ matrix.archs }}
+        run: make image ARCH=${{ matrix.arch }}
         working-directory: ${{ matrix.context }}
 
       - name: Login to Container Registry

--- a/training/Makefile
+++ b/training/Makefile
@@ -8,8 +8,8 @@ help:
 
 .PHONY: amd nvidia intel
 amd:
-	make -C amd/ image
+	make -C amd-bootc/ image
 nvidia:
-	make -C nvidia/ dtk image
+	make -C nvidia-bootc/ dtk image
 intel:
-	make -C intel/ image
+	make -C intel-bootc/ image

--- a/training/amd-bootc/Makefile
+++ b/training/amd-bootc/Makefile
@@ -8,10 +8,13 @@ IMAGE_TAG ?= latest
 CONTAINER_TOOL ?= podman
 CONTAINER_TOOL_EXTRA_ARGS ?=
 
+ARCH ?=
+
 .PHONY: image
 image:
 	"${CONTAINER_TOOL}" build \
-	        --security-opt label=disable \
+		$(ARCH:%=--platform linux/%) \
+		--security-opt label=disable \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \
 		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -11,9 +11,12 @@ CONTAINER_TOOL_EXTRA_ARGS ?=
 DRIVER_VERSION ?=
 KERNEL_VERSION ?= 
 
+ARCH ?=
+
 .PHONY: image
 image:
 	"${CONTAINER_TOOL}" build \
+		$(ARCH:%=--platform linux/%) \
 		--file Containerfile \
 		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
 		$(FROM:%=--build-arg BASEIMAGE=%) \

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -32,7 +32,7 @@ dtk:
 		.
 image:
 	"${CONTAINER_TOOL}" build \
-	        --security-opt label=disable \
+		--security-opt label=disable \
 		--cap-add SYS_ADMIN \
 		$(ARCH:%=--platform linux/%) \
 		--file Containerfile \
@@ -41,6 +41,7 @@ image:
 		$(OS_VERSION_MAJOR:%=--build-arg OS_VERSION_MAJOR=%) \
 		$(FROM:%=--build-arg BASEIMAGE=%) \
 		--build-arg DRIVER_TOOLKIT_IMAGE=${DRIVER_TOOLKIT_IMAGE} \
+		$(DRIVER_VERSION:%=--label driver-version=%) \
 		$(DRIVER_VERSION:%=--build-arg DRIVER_VERSION=%) \
 		$(CUDA_VERSION:%=--build-arg CUDA_VERSION=%) \
 		${CONTAINER_TOOL_EXTRA_ARGS} \


### PR DESCRIPTION
Addresses: #364
changes:
1) add label and arch options to builds
2) extending workflow to `intel-bootc`, `amd-bootc`, and better workflow naming

/cc @sallyom @rhatdan @lmilbaum 