### PR TITLE
update ailab-images with intel-bootc and amd-bootc

### DIFF
--- a/ailab-images.md
+++ b/ailab-images.md
@@ -12,13 +12,15 @@
 - quay.io/ai-lab/codegen:latest
 - quay.io/redhat-et/locallm-object-detection-client:latest
 
-## Dependency images
+## Dependency images (amd64)
 
 Images used in the `Bootc` aspect of this repo or tooling images
 
 - quay.io/ai-lab/nvidia-builder:latest
 - quay.io/ai-lab/instructlab-nvidia:latest
 - quay.io/ai-lab/nvidia-bootc:latest
+- quay.io/ai-lab/intel-bootc:latest
+- quay.io/ai-lab/amd-bootc:latest
 
 - quay.io/ai-lab/chromadb:latest
 - quay.io/ai-lab/model-converter:latest


### PR DESCRIPTION
Outcome of today's work building the GitHub workflows for `instructlab base` images