### PR TITLE
hardcoding repo for each workflow

### DIFF
--- a/.github/workflows/ailab_build_push_manual.yaml
+++ b/.github/workflows/ailab_build_push_manual.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build-and-push-llamacpp-python-cuda-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -54,6 +55,7 @@ jobs:
           tags: ${{ steps.build_llamacpp_python_cuda.outputs.tags }}
 
   build-and-push-llamacpp-python-vulkan-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -98,6 +100,7 @@ jobs:
           tags: ${{ steps.build_llamacpp_python_vulkan.outputs.tags }}
 
   build-and-push-llamacpp-python-base-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -141,6 +144,7 @@ jobs:
           tags: ${{ steps.build_llamacpp_python_base.outputs.tags }}
 
   build-and-push-rag-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -184,6 +188,7 @@ jobs:
           tags: ${{ steps.build_rag.outputs.tags }}
 
   build-and-push-chromadb-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -223,6 +228,7 @@ jobs:
           tags: ${{ steps.build_chromadb.outputs.tags }}
 
   build-and-push-codegen-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -263,6 +269,7 @@ jobs:
           tags: ${{ steps.build_codegen_image.outputs.tags }}
 
   build-and-push-chatbot-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -303,6 +310,7 @@ jobs:
           tags: ${{ steps.build_chatbot_image.outputs.tags }}
 
   build-and-push-summarizer-image:
+    if: github.repository == 'containers/ai-lab-recipes'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/chatbot.yaml
+++ b/.github/workflows/chatbot.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/model-converter.yaml
+++ b/.github/workflows/model-converter.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-and-push-model-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     strategy:
       matrix:
         include:

--- a/.github/workflows/model_image_build_push.yaml
+++ b/.github/workflows/model_image_build_push.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-and-push-model-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     strategy:
       matrix:
         include:

--- a/.github/workflows/model_servers.yaml
+++ b/.github/workflows/model_servers.yaml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     strategy:
       matrix:
         include:

--- a/.github/workflows/rag.yaml
+++ b/.github/workflows/rag.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/summarizer.yaml
+++ b/.github/workflows/summarizer.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
+    if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests') && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/testing-framework.yaml
+++ b/.github/workflows/testing-framework.yaml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   integration-tests:
-    if: github.repository == 'containers/ai-lab-recipes'
+    if: "github.repository == 'containers/ai-lab-recipes' && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -131,9 +131,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   release-images:
+    if: "success() && github.repository == 'containers/ai-lab-recipes'"
     runs-on: ubuntu-22.04
     needs: integration-tests
-    if: success()
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Resolves: https://redhat-internal.slack.com/archives/C06S75ZF9JT/p1714431994637879
This PR will set the following workflows to run in the main repo (`containers/ai-lab-recipes`):

- Update quay.io/ai-lab images with manual trigger (`.github/workflows/ailab_build_push_manual.yaml`)
- chatbot application (`.github/workflows/chatbot.yaml)
- codegen application (`.github/workflows/codegen.yaml)
- model-converter(`.github/workflows/model-converter.yaml`)
- all model images (`.github/workflows/model_image_build_push.yaml`)
- all model_servers (`.github/workflows/model_servers.yaml`)
- rag application (`..github/workflows/rag.yaml`)
- summarizer application (`.github/workflows/summarizer.yaml`)
- some testing framework jobs, not `test-make-targets` (`.github/workflows/testing-framework.yaml`)
    - integration tests
    - release images 
