### PR TITLE
fix bootc workflow with intel image rename

### DIFF
--- a/.github/workflows/training_bootc.yaml
+++ b/.github/workflows/training_bootc.yaml
@@ -143,7 +143,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - image_name: intel-gaudi-bootc
+          - image_name: intel-bootc
             context: training/intel-bootc
             arch: amd64
           - image_name: amd-bootc


### PR DESCRIPTION
Keeps us in alignment with #401 
/cc @rhatdan 