### PR TITLE
Add growfs service to chatbot/bootc Containerfiles

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -78,7 +78,7 @@ build:
 	podman build --squash-all $(ARCH:%=--platform linux/%) $(FROM:%=--from %) -t ${APP_IMAGE} app/
 
 .PHONY: bootc
-bootc: quadlet
+bootc: quadlet growfs
 	podman build \
 	  $(ARCH:%=--arch %) \
 	  $(FROM:%=--from %) \
@@ -155,6 +155,11 @@ install-chrome:
 		diskutil unmount "/Volumes/Google Chrome" || true; \
 		rm $(CHROME_DOWNLOAD_PATH); \
 	fi;
+
+.PHONY: growfs
+growfs: quadlet
+	# Add growfs service
+	mkdir -p build/usr; cp -R ../../common/usr/ build/usr/
 
 .PHONY: quadlet
 quadlet:

--- a/recipes/common/usr/lib/systemd/system/bootc-generic-growpart.service
+++ b/recipes/common/usr/lib/systemd/system/bootc-generic-growpart.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bootc Fallback Root Filesystem Grow
+Documentation=https://gitlab.com/fedora/bootc/docs
+# For now we skip bare metal cases, and we also have nothing to do
+# for containers.
+ConditionVirtualization=vm
+# This helps verify that we're running in a bootc/ostree based target.
+ConditionPathIsMountPoint=/sysroot
+# We want to run before any e.g. large container images might be pulled.
+DefaultDependencies=no
+Requires=sysinit.target
+After=sysinit.target
+Before=basic.target
+
+[Service]
+ExecStart=/usr/libexec/bootc-generic-growpart
+# So we can temporarily remount the sysroot writable
+MountFlags=slave
+# Just to auto-cleanup our temporary files
+PrivateTmp=yes

--- a/recipes/common/usr/lib/systemd/system/local-fs.target.wants/bootc-generic-growpart.service
+++ b/recipes/common/usr/lib/systemd/system/local-fs.target.wants/bootc-generic-growpart.service
@@ -1,0 +1,1 @@
+../bootc-generic-growpart.service

--- a/recipes/common/usr/libexec/bootc-generic-growpart
+++ b/recipes/common/usr/libexec/bootc-generic-growpart
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eu
+
+backing_device=$(findmnt -vno SOURCE /sysroot)
+echo "Backing device: ${backing_device}"
+syspath=/sys/class/block/$(basename "${backing_device}")
+if ! test -d "${syspath}"; then
+    echo "failed to find backing device ${syspath}"; exit 1
+fi
+
+# Handling devicemapper targets is a whole other thing
+case $backing_device in
+    /dev/mapper/*) "Not growing $backing_device"; exit 0 ;;
+esac
+
+# Note that we expect that the rootfs is on a partition
+partition=$(cat "${syspath}"/partition)
+
+# Walk up to find the parent blockdev
+parentpath=$(dirname "$(realpath "${syspath}")")
+devmajmin=$(cat "${parentpath}"/dev)
+parent="/dev/block/${devmajmin}"
+
+# Grow the partition
+tmpf=$(mktemp)
+# Ignore errors because growpart exits 1 if nothing changed;
+# we need to check the output for NOCHANGE:
+if ! /usr/bin/growpart "${parent}" "${partition}" > "${tmpf}"; then
+    cat "${tmpf}"
+    if grep -qEe '^NOCHANGE: ' "${tmpf}"; then
+        exit 0
+    fi
+    echo "growpart failed"
+    exit 1
+fi
+cat "${tmpf}"
+# Now, temporarily remount the sysroot writable in our mount namespace
+mount -o remount,rw /sysroot
+# And defer to systemd's growfs wrapper which handles dispatching on
+# the target filesystem type.
+/usr/lib/systemd/systemd-growfs /sysroot

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile
@@ -19,6 +19,10 @@ ARG APP_IMAGE=quay.io/ai-lab/${RECIPE}:latest
 ARG SERVER_IMAGE=quay.io/ai-lab/llamacpp_python:latest
 ARG TARGETARCH
 
+# Include growfs service
+COPY build/usr/lib /usr/lib
+COPY --chmod=0755 build/usr/libexec/bootc-generic-growpart /usr/libexec/bootc-generic-growpart
+
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 

--- a/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
+++ b/recipes/natural_language_processing/chatbot/bootc/Containerfile.nocache
@@ -15,6 +15,10 @@ RUN set -eu; mkdir -p /usr/ssh && \
 
 ARG RECIPE=chatbot
 
+# Include growfs service
+COPY build/usr/lib /usr/lib
+COPY --chmod=0755 build/usr/libexec/bootc-generic-growpart /usr/libexec/bootc-generic-growpart
+
 # Add quadlet files to setup system to automatically run AI application on boot
 COPY build/${RECIPE}.image build/${RECIPE}.kube build/${RECIPE}.yaml /usr/share/containers/systemd
 


### PR DESCRIPTION
@dwalsh  @cgwalters testing this now, added colin as author bc i copied his files from bootc-org/examples 

Tested with an `ami` with (and also with `podman-bootc`):
```
$ cd recipes/natural_language_processing/chatbot
$ make BOOTC_IMAGE=quay.io/sallyom/centos-bootc:chatbot ARCH=x86_64 CONTAINERFILE=Containerfile.nocache bootc
$ aws s3 cp ~/Desktop/bootc-disk-images/image/disk.raw s3://BUCKET_NAME
$ aws ec2 import-snapshot  --description "centos-bootc-chatbot" --disk-container file://ami-container.json
$ aws ec2 describe-import-snapshot-tasks --filters Name=task-state,Values=active

# create image (ami) from snapshot in console

$ cat ami-container.json 
{
   "Description": "centos-bootc-chatbot",
   "Format": "raw",
   "Url": "s3://BUCKET_NAME/disk.raw"
}
```