### PR TITLE
Bootc testing framework run playbook and install bootc binary

### DIFF
--- a/.github/workflows/bootc_testing_framework.yaml
+++ b/.github/workflows/bootc_testing_framework.yaml
@@ -1,4 +1,4 @@
-name: Instructlab Images Testing Framework
+name: Bootc Images Testing Framework
 
 on:
   schedule: # schedule the job to run every day at midnight
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/instructlab_testing_framework.yaml
+      - .github/workflows/bootc_testing_framework.yaml
   
   workflow_dispatch:
 
@@ -37,11 +37,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            aws_image_type: t3a.medium	
+            aws_image_type: t2.micro	
+            image_name: nvidia-bootc
             aws_ami_architecture: x86_64
-          # - arch: amd64
-          #   aws_image_type: g5.8xlarge
-          #   aws_ami_architecture: x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.4
@@ -82,10 +80,18 @@ jobs:
           echo "pem_filename=$(terraform output pem_filename | xargs)" >> $GITHUB_OUTPUT
         working-directory: terraform-test-environment-module
 
-      - name: Set up Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: '3.11'
+      - name: Ansible Collections
+        run: ansible-galaxy install -r ./provision/requirements.yml
+        working-directory: ./main/training
+
+      - name: Provision
+        run: |
+          ansible-playbook ./main/training/provision/playbook.yml \
+            -i terraform-test-environment-module/hosts.ini \
+            --private-key=terraform-test-environment-module/${{ steps.terraform-output.outputs.pem_filename }}
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: false
+          image_name: ${{ matrix.image_name }}
 
       - name: Destroy Test Environment
         id: down

--- a/training/provision/playbook.yml
+++ b/training/provision/playbook.yml
@@ -1,0 +1,21 @@
+---
+- name: Test Environment Provisioning
+  hosts: test_environments
+  remote_user: fedora
+  become: true
+  gather_facts: false
+
+  tasks:
+  
+  - name: Wait until the instance is ready
+    ansible.builtin.wait_for_connection:
+    delay: 15
+    timeout: 180
+  
+  - name: Gather facts for first time
+    ansible.builtin.setup:
+
+  - name: Required Packages
+    ansible.builtin.package:
+      name: podman
+      state: present

--- a/training/provision/requirements.yml
+++ b/training/provision/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: containers.podman
+    version: 1.13.0


### PR DESCRIPTION
Changes:

1. Rename the `instructlab_testing_framework.yaml` file to reflect the fact that we will instead be testing the bootc images: `nvidia-bootc`, `intel-bootc`, and `amd-bootc`.
2. Add a simple playbook to install the `bootc` binary from the downloaded bootc repo, and the playbooks corresponding `requirements.yml`

/cc @lmilbaum 