### PR TITLE
Timeout of 300 seconds too low

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -133,7 +133,7 @@ bootc-image-builder:
 install-chromedriver:
 	@if [[ -z "$(LOCAL_CHROMEDRIVER_EXISTS)" ]]; then \
 		if [[ -n "$(UNZIP_EXISTS)" ]]; then \
-			curl --progress-bar --max-time 300 --connect-timeout 60 -LO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
+			curl --progress-bar --max-time 3000 --connect-timeout 60 -LO $(CHROMEDRIVER_MIRROR)/$(CHROMEDRIVER_VERSION)/$(CHROMEDRIVER_DOWNLOAD_PATH); \
 			unzip $(CHROMEDRIVER_DOWNLOAD_PATH); \
 			mv chromedriver $(RECIPE_BINARIES_PATH)/; \
 			rm ./$(CHROMEDRIVER_DOWNLOAD_PATH); \
@@ -145,7 +145,7 @@ install-chromedriver:
 
 .PHONY: install-chrome
 install-chrome:
-	curl --progress-bar --max-time 300 --connect-timeout 60 -LO $(CHROME_MIRROR)
+	curl --progress-bar --max-time 3000 --connect-timeout 60 -LO $(CHROME_MIRROR)
 	@if [[ "$(OS)" == "Linux" ]]; then \
 		sudo dpkg -i $(CHROME_DOWNLOAD_PATH); \
 	elif [[ "$(OS)" == "Darwin" ]]; then \


### PR DESCRIPTION
I was on bus wifi running this, but still:

make[1]: Entering directory '/home/ecurtin/git/ai-lab-recipes/recipes/natural_language_processing/chatbot' curl --progress-bar --max-time 300 --connect-timeout 60 -LO https://www.slimjet.com/chrome/files/103.0.5060.53/google-chrome-stable_current_amd64.deb