### PR TITLE
Use ARCH variable, so we fail early on aarch64

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -51,7 +51,7 @@ ifeq ($(OS),Darwin) # This structure may vary if we upgrade chromedriver, see in
 	CHROME_DOWNLOAD_PATH := googlechrome.dmg
 else ifeq ($(OS),Linux)
 	CHROMEDRIVER_DOWNLOAD_PATH := chromedriver_linux64.zip
-	CHROME_DOWNLOAD_PATH := google-chrome-stable_current_amd64.deb
+	CHROME_DOWNLOAD_PATH := google-chrome-stable_current_$(ARCH).deb
 endif
 
 CHROME_MIRROR := https://www.slimjet.com/chrome/files/$(CHROMEDRIVER_VERSION)/$(CHROME_DOWNLOAD_PATH)


### PR DESCRIPTION
When using this on alternate platform like aarch64, at least it will cause the make script to fail early when the aarch64 file doesn't exist, rather than incorrectly downloading the amd64 version. aarch64 chrome may get packaged in future also.