### PR TITLE
fix(growfs): Correct the source path to be copied

### DIFF
--- a/recipes/common/Makefile.common
+++ b/recipes/common/Makefile.common
@@ -159,7 +159,7 @@ install-chrome:
 .PHONY: growfs
 growfs: quadlet
 	# Add growfs service
-	mkdir -p build/usr; cp -R ../../common/usr/ build/usr/
+	mkdir build; cp -R ../../common/usr build/
 
 .PHONY: quadlet
 quadlet:


### PR DESCRIPTION
The current source path is `../../common/usr` and it will copy to destination path `build/usr/usr/`. I checked that the result are different between Linux and MacOS, so modify to adapt different platforms.

fix: #410