### PR TITLE
intel training container is now pulling in vllm container

### DIFF
--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -6,6 +6,8 @@ include ../common/Makefile.common
 bootc: growfs
 	"${CONTAINER_TOOL}" build \
 		$(ARCH:%=--platform linux/%) \
+		--security-opt label=disable \
+		--cap-add SYS_ADMIN \
 		--file Containerfile \
 		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
 		-v ${OUTDIR}:/run/.input:ro \


### PR DESCRIPTION
In order to run podman inside of a container we need to disable SELinux enforcement and add CAP_SYS_ADMIN to allow mounting of overlay file systems. This matches what we are doing in the nvidia and amd bootc containers.