### PR TITLE
chore: handle some AVX flags properly on certain Intel CPUs

### DIFF
--- a/model_servers/llamacpp_python/base/Containerfile
+++ b/model_servers/llamacpp_python/base/Containerfile
@@ -1,6 +1,9 @@
-FROM registry.access.redhat.com/ubi9/python-311:1-52.1712567218
+FROM registry.access.redhat.com/ubi9/python-311:1-62
 WORKDIR /locallm
 COPY src .
-RUN pip install --no-cache-dir --verbose -r ./requirements.txt
+USER root
+RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
+USER 1001
+RUN CC="/opt/rh/gcc-toolset-13/root/usr/bin/gcc" CXX="/opt/rh/gcc-toolset-13/root/usr/bin/g++"  pip install --no-cache-dir --verbose -r ./requirements.txt
 EXPOSE 8001
 ENTRYPOINT [ "sh", "./run.sh" ]


### PR DESCRIPTION
else we may face the issue 
```
Error: unsupported instruction `vpdpbusd'
```


related issue
https://github.com/ggerganov/llama.cpp/issues/5316

