### PR TITLE
add interrupt to llamacpp

### DIFF
--- a/model_servers/llamacpp_python/src/run.sh
+++ b/model_servers/llamacpp_python/src/run.sh
@@ -5,7 +5,7 @@ if [ ${CONFIG_PATH} ] || [[ ${MODEL_PATH} && ${CONFIG_PATH} ]]; then
 fi
 
 if [ ${MODEL_PATH} ]; then
-    python -m llama_cpp.server --model ${MODEL_PATH} --host ${HOST:=0.0.0.0} --port ${PORT:=8001} --n_gpu_layers ${GPU_LAYERS:=0} --clip_model_path ${CLIP_MODEL_PATH:=None} --chat_format ${MODEL_CHAT_FORMAT:="llama-2"}
+    python -m llama_cpp.server --model ${MODEL_PATH} --host ${HOST:=0.0.0.0} --port ${PORT:=8001} --n_gpu_layers ${GPU_LAYERS:=0} --clip_model_path ${CLIP_MODEL_PATH:=None} --chat_format ${MODEL_CHAT_FORMAT:="llama-2"} --interrupt_requests ${INTERRUPT_REQUESTS:=False}
     exit 0
 fi
 


### PR DESCRIPTION
Partially addresses https://github.com/containers/ai-lab-recipes/issues/497

This will prevent the llamacpp_python model server from crashing if you send a second request while the model is streaming output. It seems to still crash if a second request is sent while the model is processing the first.  