### PR TITLE
Lower ConversationBufferWindowMemory

### DIFF
--- a/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
+++ b/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
@@ -56,7 +56,7 @@ for msg in st.session_state.messages:
 
 @st.cache_resource()
 def memory():
-    memory = ConversationBufferWindowMemory(return_messages=True,k=10)
+    memory = ConversationBufferWindowMemory(return_messages=True,k=3)
     return memory
 
 model_name = "" 


### PR DESCRIPTION
the ConversationBufferWindowMemory size was set too high, letting the conversation history reach the context limit before clearing out earlier messages, and causing the server to crash.  This PR lowers the value so that we only retain the last 3 chat messages in the history. 

Should address  https://github.com/containers/podman-desktop-extension-ai-lab/issues/1083