### PR TITLE
ilab-wrapper: fix GPU_AMOUNT check

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -33,7 +33,7 @@ if [[ -z "${GPU_AMOUNT}" ]]; then
 	fi
 fi
 
-if [[ "$GPU_AMOUNT" -le 2 ]]; then
+if [[ "$GPU_AMOUNT" -lt 2 ]]; then
 	echo "WARNING: You need at least 2 GPUs to load full precision models"
 fi
 


### PR DESCRIPTION
No need to emit this warning on a 2x GPU system.