### PR TITLE
Configure model for chatbot and codegen recipes

### DIFF
--- a/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
+++ b/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
@@ -67,7 +67,7 @@ def memory():
     memory = ConversationBufferWindowMemory(return_messages=True,k=3)
     return memory
 
-model_name = "" 
+model_name = os.getenv("MODEL_NAME", "") 
 
 if server == "Ollama":
     models = get_models()

--- a/recipes/natural_language_processing/codegen/app/codegen-app.py
+++ b/recipes/natural_language_processing/codegen/app/codegen-app.py
@@ -39,7 +39,10 @@ if "messages" not in st.session_state:
 for msg in st.session_state.messages:
     st.chat_message(msg["role"]).write(msg["content"])
 
-llm = ChatOpenAI(base_url=model_service, 
+model_name = os.getenv("MODEL_NAME", "")
+
+llm = ChatOpenAI(base_url=model_service,
+                 model=model_name,
                  api_key="EMPTY",
                  streaming=True)
 


### PR DESCRIPTION
A couple small changes to the codegen and chatbot recipes, after doing some work with them using a vLLM model service:
- Pass in model name to the llm object in `codegen-app.py`
- Allow environment variable to configure model name in both `chatbot_ui.py` and `codegen-app.py`

