### PR TITLE
Fix Makefiles to allow alternative container engines

### DIFF
--- a/model_servers/common/Makefile.common
+++ b/model_servers/common/Makefile.common
@@ -1,3 +1,4 @@
+CONTAINER_TOOL ?= podman
 REGISTRY ?= quay.io
 REGISTRY_ORG ?= ai-lab
 COMPONENT ?= model_servers

--- a/model_servers/llamacpp_python/Makefile
+++ b/model_servers/llamacpp_python/Makefile
@@ -17,11 +17,11 @@ all: build download-model-granite run
 
 .PHONY: build-cuda
 build-cuda:
-	podman build --squash-all -t $(CUDA_IMAGE) . -f cuda/Containerfile
+	"${CONTAINER_TOOL}"  build --squash --layers=false -t $(CUDA_IMAGE) . -f cuda/Containerfile
 
 .PHONY: build-vulkan
 build-vulkan:
-	podman build --squash-all -t $(VULKAN_IMAGE) . -f vulkan/Containerfile
+	"${CONTAINER_TOOL}"  build --squash --layers=false -t $(VULKAN_IMAGE) . -f vulkan/Containerfile
 
 .PHONY: download-model-granite # default model
 download-model-granite:

--- a/models/Makefile
+++ b/models/Makefile
@@ -1,3 +1,4 @@
+CONTAINER_TOOL ?= podman
 MODEL_URL ?= https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf
 MODEL_NAME ?= granite-7b-lab-Q4_K_M.gguf
 
@@ -9,7 +10,7 @@ IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/$(MODEL_NAME):latest
 
 .PHONY: build
 build:
-	podman build $(MODEL_URL:%=--build-arg MODEL_URL=%) -f Containerfile -t ${IMAGE} .
+	"${CONTAINER_TOOL}"  build $(MODEL_URL:%=--build-arg MODEL_URL=%) -f Containerfile -t ${IMAGE} .
 
 .PHONY: download-model
 download-model:

--- a/recipes/natural_language_processing/rag/Makefile
+++ b/recipes/natural_language_processing/rag/Makefile
@@ -16,7 +16,7 @@ run:
 # rag requires custom bootc because it uses an extra build-arg for CHROMADB_IMAGE (other apps use ../../common/Makefile.common target)
 .PHONY: bootc
 bootc: quadlet
-	podman build \
+	"${CONTAINER_TOOL}"  build \
 	  $(ARCH:%=--arch %) \
 	  $(FROM:%=--from %) \
 	  $(AUTH_JSON:%=-v %:/run/containers/0/auth.json) \

--- a/training/Makefile
+++ b/training/Makefile
@@ -94,7 +94,7 @@ cloud: cloud-amd cloud-intel cloud
 
 #
 # We often see users running out of space. These commands are useful for freeing wasted space.
-# Note becarful to not run this target if a podman build is in progress.
+# Note be careful to not run this target if a podman build is in progress.
 #
 .PHONY: prune
 prune:

--- a/training/deepspeed/Makefile
+++ b/training/deepspeed/Makefile
@@ -13,5 +13,5 @@ image:
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
 		--file Containerfile \
 		--layers=false \
-		--squash-all \
+		--squash \
 		--tag oci:../build/deepspeed-trainer

--- a/training/instructlab/Makefile
+++ b/training/instructlab/Makefile
@@ -1,3 +1,5 @@
+CONTAINER_TOOL ?= podman
+
 MAKEFLAGS += -j2
 
 help:
@@ -24,14 +26,14 @@ instructlab:
 .PHONY: nvidia
 nvidia: instructlab
 	rm -rf ../build/instructlab-$@
-	podman build --layers=false --squash-all -t oci:../build/instructlab-$@ instructlab/containers/cuda
+	"${CONTAINER_TOOL}"  build --layers=false --squash -t oci:../build/instructlab-$@ instructlab/containers/cuda
 
 .PHONY: amd
 amd: instructlab
 	rm -rf ../build/instructlab-$@
-	podman build --layers=false --squash-all -t oci:../build/instructlab-$@ -f instructlab/containers/rocm/Containerfile instructlab
+	"${CONTAINER_TOOL}"  build --layers=false --squash -t oci:../build/instructlab-$@ -f instructlab/containers/rocm/Containerfile instructlab
 
 .PHONY: intel
 intel: instructlab
 	rm -rf ../build/instructlab-$@
-	podman build --layers=false --squash-all -t oci:../build/instructlab-$@ -f instructlab/containers/hpu/Containerfile instructlab
+	"${CONTAINER_TOOL}"  build --layers=false --squash -t oci:../build/instructlab-$@ -f instructlab/containers/hpu/Containerfile instructlab

--- a/training/vllm/Makefile
+++ b/training/vllm/Makefile
@@ -12,6 +12,6 @@ image:
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
 		--file Containerfile \
 		--layers=false \
-		--squash-all \
+		--squash \
 		--tag oci:../build/vllm \
 		${CONTAINER_TOOL_EXTRA_ARGS} .

--- a/vector_dbs/chromadb/Makefile
+++ b/vector_dbs/chromadb/Makefile
@@ -1,6 +1,7 @@
+CONTAINER_TOOL ?= podman
 APP ?= chromadb
 APPIMAGE ?= quay.io/ai-lab/${APP}:latest
 
 .PHONY: build
 build:
-	podman build -f Containerfile -t ${APPIMAGE} .
+	"${CONTAINER_TOOL}" build -f Containerfile -t ${APPIMAGE} .

--- a/vector_dbs/milvus/Makefile
+++ b/vector_dbs/milvus/Makefile
@@ -1,3 +1,4 @@
+CONTAINER_TOOL ?= podman
 REGISTRY ?= quay.io
 REGISTRY_ORG ?= ai-lab
 COMPONENT = vector_dbs
@@ -15,7 +16,7 @@ LIB_MILVUS_DIR_MOUNTPATH := $(shell pwd)/volumes/milvus
 
 .PHONY: build
 build:
-	podman build --platform $(PLATFORM) -f Containerfile -t ${IMAGE} .
+	"${CONTAINER_TOOL}"  build --platform $(PLATFORM) -f Containerfile -t ${IMAGE} .
 
 .PHONY: run
 run:


### PR DESCRIPTION
Some users want to use buildah instead of podman to build their container engines.

Buildah does not support --squash-all but after examining the podman code --squash-all ends up just being the equivalent of "--squash --layers=false"