### PR TITLE
try to fix the renovate bot from breaking milvus

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     },
     {
       "matchPackageNames": ["pymilvus"],
-      "allowedVersions": "<=2.4.2"
+      "allowedVersions": "<=2.4.1"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
     {
       "matchPackageNames": ["langchain-openai"],
       "allowedVersions": "<=0.1.7"
+    },
+    {
+      "matchPackageNames": ["pymilvus"],
+      "allowedVersions": "<=2.4.2"
     }
   ]
 }


### PR DESCRIPTION
Renovate bot keeps hitting a failure while attempting to update the pymilvus version. Checking to ensure that if we set this we will stop the bot from attempting to push new versions of that package and burning money on bad runs.