### PR TITLE
Add pciutils to the OS image

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -8,6 +8,7 @@ COPY build/usr /usr
 
 ARG EXTRA_RPM_PACKAGES=''
 RUN dnf install -y \
+  pciuils \
   rocm-smi \
   ${EXTRA_RPM_PACKAGES} \
   && dnf clean all

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -24,10 +24,10 @@ RUN if [ -f /etc/centos-release ]; then \
        dnf -y update \
        && dnf -y install epel-release \
        && crb enable \
-       && dnf -y install ninja-build pandoc;\
+       && dnf -y install ninja-build pandoc pciutils;\
     fi \
     && dnf -y update \
-    && dnf install -y dkms ninja-build pandoc \
+    && dnf install -y dkms ninja-build pandoc pciutils \
     && dnf install -y habanalabs-firmware-${DRIVER_VERSION}.${REDHAT_VERSION} \
     habanalabs-${DRIVER_VERSION}.${REDHAT_VERSION} \
     habanalabs-rdma-core-${DRIVER_VERSION}.${REDHAT_VERSION} \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -117,6 +117,7 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
     && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel${OS_VERSION_MAJOR}/${CUDA_REPO_ARCH}/cuda-rhel${OS_VERSION_MAJOR}.repo \
     && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \
     && dnf install -y \
+        pciutils \
         nvidia-driver-cuda-${DRIVER_VERSION} \
         nvidia-driver-libs-${DRIVER_VERSION} \
         nvidia-driver-NVML-${DRIVER_VERSION} \


### PR DESCRIPTION
The `lspci` command is frequently used to inspect the hardware on a server. Adding it to the OS image would help users to troubleshoot deployment and configuration issues.