### PR TITLE
Add tmux to the bootc image

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -10,6 +10,7 @@ ARG EXTRA_RPM_PACKAGES=''
 RUN dnf install -y \
   pciuils \
   rocm-smi \
+  tmux \
   ${EXTRA_RPM_PACKAGES} \
   && dnf clean all
 

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -24,10 +24,10 @@ RUN if [ -f /etc/centos-release ]; then \
        dnf -y update \
        && dnf -y install epel-release \
        && crb enable \
-       && dnf -y install ninja-build pandoc pciutils;\
+       && dnf -y install ninja-build pandoc pciutils tmux;\
     fi \
     && dnf -y update \
-    && dnf install -y dkms ninja-build pandoc pciutils \
+    && dnf install -y dkms ninja-build pandoc pciutils tmux \
     && dnf install -y habanalabs-firmware-${DRIVER_VERSION}.${REDHAT_VERSION} \
     habanalabs-${DRIVER_VERSION}.${REDHAT_VERSION} \
     habanalabs-rdma-core-${DRIVER_VERSION}.${REDHAT_VERSION} \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -118,6 +118,7 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
     && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \
     && dnf install -y \
         pciutils \
+        tmux \
         nvidia-driver-cuda-${DRIVER_VERSION} \
         nvidia-driver-libs-${DRIVER_VERSION} \
         nvidia-driver-NVML-${DRIVER_VERSION} \


### PR DESCRIPTION
Many commands that are run for SDG and training can take a lot of time, so there is a risk to have a network disconnection during the task. With `tmux`, users have the ability to detach the jobs from their SSH session and let the tasks run for a very long time.