### PR TITLE
Temporary fix for bootc CI builds

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -96,7 +96,8 @@ USER root
 
 COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /rpms/
 COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
-
+# Temporary workaround until the permanent fix for libdnf is merged
+RUN mv /etc/selinux /etc/selinux.tmp											   
 RUN dnf install -y /rpms/kmod-nvidia-*.rpm
 
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
@@ -133,6 +134,7 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
         dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \
     fi \
     && dnf clean all \
+    && mv /etc/selinux.tmp /etc/selinux \
     && ln -s /usr/lib/systemd/system/nvidia-toolkit-firstboot.service /usr/lib/systemd/system/basic.target.wants/nvidia-toolkit-firstboot.service \
     && echo "blacklist nouveau" > /etc/modprobe.d/blacklist_nouveau.conf
 


### PR DESCRIPTION
Konflux CI fails when building using bootc images as base throwing this error:
`Error: Cannot create repo temporary directory "/var/cache/dnf/baseos-044cae74d71fe9ea/libdnf.1jsyRp": Permission denied`
 This temporary workaround is needed for build pipeline to work on Konflux CI until libdnf fix is merged to RHEL. 
References:
https://issues.redhat.com/browse/RHEL-39796
https://github.com/rpm-software-management/libdnf/pull/1665

It should be removed once the permanent fix is merged.