### PR TITLE
Make growfs conditional

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -18,8 +18,8 @@ USER builder
 WORKDIR /home/builder
 COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 
-# Include growfs service
-COPY build/usr /usr
+# Include growfs service if needed
+RUN if [ -d "build/usr" ]; then cp -r build/usr /usr; fi
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
         NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \


### PR DESCRIPTION
growfs is created by Makefile and CI does not use it. Also if I'm not misktaken growfs is only used for disk images creation. By changing this, growfs files will only be created when `Makefile` is run, so CI build pipelines can use the `Containerfile` and growfs can be also used when needed running `make`.

If change is accepted I'll submit additional PRs for amd and intel.