### PR TITLE
Adds models to bootc-models image

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -1,9 +1,9 @@
 MAKEFLAGS += -j2
 
-.PHONY: all
-all: deepspeed vllm
-
 default: help
+
+.PHONY: all
+all: deepspeed vllm models
 
 help:
 	@echo "To build a bootable container image you first need to create instructlab container images for a particular vendor "
@@ -72,11 +72,11 @@ vllm:
 #
 .PHONY: amd nvidia intel vllm
 amd:
-	make -C amd-bootc/ bootc
+	make -C amd-bootc/ bootc bootc-models
 intel:
-	make -C intel-bootc/ bootc
+	make -C intel-bootc/ bootc bootc-models
 nvidia:
-	make -C nvidia-bootc/ dtk bootc
+	make -C nvidia-bootc/ dtk bootc bootc-models
 
 #
 # Make Bootc container images preinstalled with cloud-init
@@ -116,6 +116,10 @@ disk-intel:
 .PHONY: disk-nvidia
 disk-nvidia:
 	make -C nvidia-bootc/ bootc-image-builder
+
+.PHONY: models
+models:
+	make -C model
 
 .PHONY: clean
 clean:

--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -8,9 +8,6 @@ FROM ${INSTRUCTLAB_IMAGE} AS ilab
 # Define the base image for the second stage
 FROM ${BASEIMAGE}
 
-# Copy files from the first stage
-COPY --from=ilab /opt/app-root/bin/ilab /usr/local/bin/ilab
-
 ADD rocm.repo /etc/yum.repos.d/rocm.repo
 
 # Include growfs service
@@ -21,13 +18,15 @@ RUN dnf install -y \
   pciutils \
   rocm-smi \
   tmux \
+  rsync \
   ${EXTRA_RPM_PACKAGES} \
   && dnf clean all
 
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
 RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
-        /etc/containers/storage.conf
+	/etc/containers/storage.conf && \
+	cp /run/.input/ilab /usr/local/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-amd:latest"
 ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -6,6 +6,7 @@ REGISTRY_ORG ?= ai-lab
 IMAGE_NAME ?= $(VENDOR)-bootc
 IMAGE_TAG ?= latest
 BOOTC_IMAGE ?= ${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}
+BOOTC_MODELS_IMAGE ?= ${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}-models:${IMAGE_TAG}
 
 CONTAINER_TOOL ?= podman
 CONTAINER_TOOL_EXTRA_ARGS ?=
@@ -33,16 +34,27 @@ KERNEL_VERSION ?=
 INSTRUCTLAB_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/instructlab-$(VENDOR):$(IMAGE_TAG)
 VLLM_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/vllm:$(IMAGE_TAG)
 TRAIN_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/deepspeed-trainer:$(IMAGE_TAG)
+WRAPPER = $(CURDIR)/../ilab-wrapper/ilab
+QLORA_WRAPPER = $(CURDIR)/../ilab-wrapper/ilab-qlora
+TRAIN_WRAPPER =  $(CURDIR)/../ilab-wrapper/ilab-training-launcher
 OUTDIR = $(CURDIR)/../build
+MODELS_CONTAINERFILE = $(OUTDIR)/Containerfile.models
 
 SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub 2> /dev/null)
 
-.PHONY: prepare-files
-prepare-files: $(OUTDIR)
+ .PHONY: prepare-files
+prepare-files: $(OUTDIR)/$(WRAPPER) $(OUTDIR)/$(QLORA_WRAPPER) $(OUTDIR)/$(TRAIN_WRAPPER) $(OUTDIR)
 
 .PHONY: $(OUTDIR)
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
+
+$(OUTDIR)/$(WRAPPER): $(OUTDIR)
+	cp -pf $(WRAPPER) $(OUTDIR)
+$(OUTDIR)/$(QLORA_WRAPPER): $(OUTDIR)
+	cp -pf $(QLORA_WRAPPER) $(OUTDIR)
+$(OUTDIR)/$(TRAIN_WRAPPER): $(OUTDIR)
+	cp -pf $(TRAIN_WRAPPER) $(OUTDIR)
 
 .PHONY: check-sshkey
 check-sshkey:
@@ -87,6 +99,22 @@ bootc-image-builder:
 	  -v ./build/store:/store \
 	  -v ./build:/output \
 	  $(BOOTC_IMAGE)
+
+.PHONY: generate-model-cfile
+generate-model-cfile:
+	echo "FROM ${BOOTC_IMAGE}" > ${MODELS_CONTAINERFILE}
+	echo "RUN rsync -ah --progress --exclude '.hug*' --exclude '*.safetensors' /run/.input/models /usr/share" >> ${MODELS_CONTAINERFILE}
+	"${CONTAINER_TOOL}" run -v ../common:/work:z -v ${OUTDIR}:/run/.input:ro model-downloader:latest python3 /work/generate-model-cfile.py /run/.input/models >> ${MODELS_CONTAINERFILE}
+
+.PHONY: bootc-models
+bootc-models: generate-model-cfile
+	"${CONTAINER_TOOL}" build \
+		$(ARCH:%=--platform linux/%) \
+		--file ${MODELS_CONTAINERFILE} \
+		--security-opt label=disable \
+		--tag "${BOOTC_MODELS_IMAGE}" \
+		-v ${OUTDIR}:/run/.input:ro \
+		${CONTAINER_TOOL_EXTRA_ARGS} .
 
 .PHONY: clean
 clean:

--- a/training/common/generate-model-cfile.py
+++ b/training/common/generate-model-cfile.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+def isHuggingDir(elements):
+	for n in s:
+		if n.startswith(".hug"):
+			return True
+	return False
+
+def printNonEmpty(*args):
+	if len(args[0]) > 0:
+		print(*args)
+
+dir = sys.argv[1]
+cwd = os.getcwd()
+os.chdir(dir)
+c = 0
+result=""
+for root, dirs, files in os.walk("."):
+	s = root.split(os.path.sep)
+	s.pop(0)
+	if isHuggingDir(s):
+		continue
+	for file in files:
+		if not file.endswith(".safetensors"):
+			continue
+		path = os.path.join("/run", ".input", "models", *s, file)
+		partial = os.path.join("/usr", "share", "models", *s, file)
+		cmd = f"rsync -ah --progress {path} {partial}"
+		if c % 4 != 0:
+			result = f"{result} \\\n\t && {cmd}"
+		else:
+			printNonEmpty(result)
+			result = f"RUN {cmd}"
+		c += 1
+printNonEmpty(result)
+os.chdir(cwd)

--- a/training/instructlab/Makefile
+++ b/training/instructlab/Makefile
@@ -42,19 +42,19 @@ intel: instructlab
 	"${CONTAINER_TOOL}" build --squash-all -t oci:../build/instructlab-$@  -f instructlab/containers/hpu/Containerfile instructlab
 
 .PHONY: nvidia-quay
-nvidia: instructlab
+nvidia-quay: instructlab
 	rm -rf ../build/instructlab-$@
 	"${CONTAINER_TOOL}" build --squash-all -t quay.io/ai-lab/instructlab-nvidia:latest instructlab/containers/cuda
 	"${CONTAINER_TOOL}" push quay.io/ai-lab/instructlab-nvidia:latest
 
 .PHONY: amd-quay
-amd: instructlab
+amd-quay: instructlab
 	rm -rf ../build/instructlab-$@
 	"${CONTAINER_TOOL}" build --squash-all -t quay.io/ai-lab/instructlab-amd:latest -f instructlab/containers/rocm/Containerfile instructlab
 	"${CONTAINER_TOOL}" push quay.io/ai-lab/instructlab-amd:latest
 
 .PHONY: intel-quay
-intel: instructlab
+intel-quay: instructlab
 	rm -rf ../build/instructlab-$@
 	"${CONTAINER_TOOL}" build --squash-all -t quay.io/ai-lab/instructlab-intel:latest -f instructlab/containers/hpu/Containerfile instructlab
 	"${CONTAINER_TOOL}" push quay.io/ai-lab/instructlab-intel:latest

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -18,7 +18,7 @@ RUN . /etc/os-release \
        kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
        kernel-devel-matched${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
        kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
-       elfutils-libelf-devel gcc make git kmod \
+       elfutils-libelf-devel gcc make git kmod rsync \
        vim-filesystem rpm-build wget ninja-build pciutils tmux \
     && rpm -ivh https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pandoc-common-2.14.0.3-17.el9.noarch.rpm \
     && rpm -ivh https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pandoc-2.14.0.3-17.el9.x86_64.rpm \

--- a/training/model/Containerfile
+++ b/training/model/Containerfile
@@ -1,11 +1,3 @@
 FROM registry.access.redhat.com/ubi9/ubi
-
-ARG MODEL_REPO=''
-ARG MODEL_NAME=''
-ARG MODEL_PATH=''
-
-RUN dnf install -y python3-pip && python3 -m pip install huggingface_hub
-RUN mkdir -p "${MODEL_PATH}" \
-    && echo from huggingface_hub import snapshot_download > /root/hf_download \
-    && echo snapshot_download\(repo_id=\'${MODEL_REPO}\', local_dir=\'${MODEL_PATH}\', local_dir_use_symlinks=False\) >> /root/hf_download \
-    && python3 /root/hf_download
+RUN dnf install -y python3-pip && python3 -m pip install huggingface_hub[cli]
+WORKDIR /download

--- a/training/model/Makefile
+++ b/training/model/Makefile
@@ -1,23 +1,23 @@
-FROM ?= 
-
-REGISTRY ?= quay.io
-REGISTRY_ORG ?= ai-lab
-IMAGE_NAME ?= granite-7b-lab
-IMAGE_TAG ?= latest
-
 CONTAINER_TOOL ?= podman
 CONTAINER_TOOL_EXTRA_ARGS ?=
 
-MODEL_REPO ?= ibm/granite-7b-base
-MODEL_PATH ?= /usr/share/ai-model
+GRANITE_MODEL_REPO ?= ibm/granite-7b-base
+MIXTRAL_MODEL_REPO ?= mistralai/Mixtral-8x7B-Instruct-v0.1
+
+default: download
 
 .PHONY: image
 image:
 	"${CONTAINER_TOOL}" build \
-		$(FROM:%=--build-arg BASEIMAGE=%) \
-		$(MODEL_PATH:%=--build-arg MODEL_PATH=%) \
-		$(MODEL_REPO:%=--build-arg MODEL_REPO=%) \
-		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
 		--file Containerfile \
-		--tag "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG}" \
+		--tag model-downloader:latest \
 		${CONTAINER_TOOL_EXTRA_ARGS} .
+.PHONY: download
+download: image
+	$(MAKE) MODEL_REPO=$(GRANITE_MODEL_REPO) download-model
+	$(MAKE) MODEL_REPO=$(MIXTRAL_MODEL_REPO) download-model
+
+.PHONY: download-model
+download-model:
+	mkdir -p ../build/models
+	podman run -e HF_TOKEN -v ../build/models:/download:z -t model-downloader huggingface-cli download --exclude "*.pt" --local-dir "/download/$(MODEL_REPO)" "$(MODEL_REPO)"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -131,6 +131,7 @@ RUN if [ "${TARGET_ARCH}" == "" ]; then \
         cuda-cudart-${CUDA_DASHED_VERSION} \
         nvidia-persistenced-${DRIVER_VERSION} \
         nvidia-container-toolkit \
+	rsync \
         ${EXTRA_RPM_PACKAGES} \
     && if [ "$DRIVER_TYPE" != "vgpu" ] && [ "$TARGET_ARCH" != "arm64" ]; then \
         versionArray=(${DRIVER_VERSION//./ }); \
@@ -154,15 +155,13 @@ RUN if [ -n "${SSHPUBKEY}" ]; then \
 	    echo ${SSHPUBKEY} > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys; \
 fi
 
-# Copy files from the first stage
-COPY --from=ilab /opt/app-root/bin/ilab /usr/local/bin/ilab
-
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
 # Also make sure not to duplicate if a base image already has it specified.
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
-        /etc/containers/storage.conf
+	/etc/containers/storage.conf && \
+	cp /run/.input/ilab /usr/local/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -7,7 +7,7 @@ DRIVER_TOOLKIT_IMAGE = ${REGISTRY}/${REGISTRY_ORG}/${DTK_IMAGE_NAME}:${DTK_IMAGE
 CUDA_VERSION ?=
 OS_VERSION_MAJOR ?=
 ENABLE_RT ?=
-
+MODELS_CONTAINERFILE = $(OUTDIR)/Containerfile.models
 include ../common/Makefile.common
 
 default: bootc


### PR DESCRIPTION
- Fix wrong script install (container lab used over wrapper [wont run on its own])
  + Restores elements that were unintentionally removed
- Fix quay tags
- Introduce "$ARCH-bootc-models" images in addition to bootc that include models
   + To workaround a quay limitation (image pushes with large layers fail) large model files are structured in dynamic assembled batches so that each layer is a safe ~ 20gb

To build:

## after making containers
make models
make nvidia 

Note that these models are quite large (87gb + 27gb) so you need fast storage for this to complete in a reasonable time from ( I was using a raid0 8x SSD to get this to 10-15 mins to bundle models )