### PR TITLE
Use multi-stage to build the Intel bootc image

### DIFF
--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -1,61 +1,55 @@
+ARG DRIVER_TOOLKIT_IMAGE="quay.io/ai-lab/nvidia-builder:latest"
 ARG BASEIMAGE="quay.io/centos-bootc/centos-bootc:stream9"
-FROM ${BASEIMAGE}
 
-ARG OS_VERSION_MAJOR=''
-ARG DRIVER_VERSION=1.16.0-526
-ARG TARGET_ARCH=''
-ARG KERNEL_VERSION=''
-ARG REDHAT_VERSION='el9'
+FROM ${DRIVER_TOOLKIT_IMAGE} as builder
+
+ARG DRIVER_VERSION=1.16.1-7
 ARG HABANA_REPO="https://vault.habana.ai/artifactory/rhel/9/9.2"
-ARG KERNEL_DIR="/usr/lib/modules/${KERNEL_VERSION}.el9_4.x86_64/build"
-ARG KERNEL_FULL_VER="${KERNEL_VERSION}.el9_4.x86"
 
+WORKDIR /home/builder
 
 RUN . /etc/os-release \
-    && export OS_VERSION_MAJOR="${OS_VERSION_MAJOR:-$(echo ${VERSION} | cut -d'.' -f 1)}" \
-    && export TARGET_ARCH="${TARGET_ARCH:-$(arch)}" \
-    && dnf -y update && dnf -y install kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
-       kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
-       kernel-devel-matched${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
-       kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION}.el9_4 \
-       elfutils-libelf-devel gcc make git kmod rsync \
-       vim-filesystem rpm-build wget ninja-build pciutils tmux \
-    && rpm -ivh https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pandoc-common-2.14.0.3-17.el9.noarch.rpm \
-    && rpm -ivh https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/pandoc-2.14.0.3-17.el9.x86_64.rpm \
-    && dnf -y clean all \
-    && cd sources \
-    && wget ${HABANA_REPO}/habanalabs-firmware-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm \
-    ${HABANA_REPO}/habanalabs-${DRIVER_VERSION}.${REDHAT_VERSION}.noarch.rpm \
-    ${HABANA_REPO}/habanalabs-rdma-core-${DRIVER_VERSION}.${REDHAT_VERSION}.noarch.rpm \
-    ${HABANA_REPO}/habanalabs-firmware-tools-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm \
-    ${HABANA_REPO}/habanalabs-thunk-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm \ 
-    && rpm2cpio habanalabs-firmware-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm | cpio -idmv \
-    && rpm2cpio habanalabs-${DRIVER_VERSION}.${REDHAT_VERSION}.noarch.rpm | cpio -idmv \
-    && rpm2cpio habanalabs-rdma-core-${DRIVER_VERSION}.${REDHAT_VERSION}.noarch.rpm | cpio -idmv \
-    && rpm2cpio habanalabs-firmware-tools-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm | cpio -idmv \
-    && rpm2cpio habanalabs-thunk-${DRIVER_VERSION}.${REDHAT_VERSION}.${TARGET_ARCH}.rpm | cpio -idmv \ 
-    && rm *.rpm \
-    && cp -r /sources/etc/* /etc/ \
-    && cp -r /sources/lib/* /lib/ \
-    && cp -r /sources/usr/* /usr/ \
-    && cp -r /sources/opt/* /opt/
+    && export OS_VERSION_MAJOR=$(echo ${VERSION} | cut -d'.' -f 1) \
+    && export KERNEL_VERSION=$(rpm -q --qf '%{VERSION}-%{RELEASE}' kernel-core) \
+    && export TARGET_ARCH=$(rpm -q --qf '%{ARCH}' kernel-core) \
+    && rpm2cpio ${HABANA_REPO}/habanalabs-firmware-${DRIVER_VERSION}.el${OS_VERSION_MAJOR}.${TARGET_ARCH}.rpm | cpio -idmv \
+    && rpm2cpio ${HABANA_REPO}/habanalabs-${DRIVER_VERSION}.el${OS_VERSION_MAJOR}.noarch.rpm | cpio -idmv \
+    && rpm2cpio ${HABANA_REPO}/habanalabs-rdma-core-${DRIVER_VERSION}.el${OS_VERSION_MAJOR}.noarch.rpm | cpio -idmv \
+    && rpm2cpio ${HABANA_REPO}/habanalabs-firmware-tools-${DRIVER_VERSION}.el${OS_VERSION_MAJOR}.${TARGET_ARCH}.rpm | cpio -idmv \
+    && rpm2cpio ${HABANA_REPO}/habanalabs-thunk-${DRIVER_VERSION}.el${OS_VERSION_MAJOR}.${TARGET_ARCH}.rpm | cpio -idmv \ 
+    && pushd usr/src/habanalabs-${DRIVER_VERSION} \
+    && make -f Makefile.nic KVERSION=${KERNEL_VERSION}.${TARGET_ARCH} \
+    && make -f Makefile KVERSION=${KERNEL_VERSION}.${TARGET_ARCH} \
+    && pushd drivers/infiniband/hw/hbl \
+    && make KVERSION=${KERNEL_VERSION}.${TARGET_ARCH}
 
-WORKDIR /usr/src/habanalabs-${DRIVER_VERSION}
-RUN make -f Makefile.nic && make -f Makefile && cd drivers/infiniband/hw/hlib && make
-RUN mkdir /lib/modules/${KERNEL_VERSION}.el9_4.x86_64/extra
-RUN cp drivers/accel/habanalabs/habanalabs.ko /lib/modules/${KERNEL_VERSION}.el9_4.x86_64/extra/ \
-    && cp drivers/infiniband/hw/hlib/habanalabs_ib.ko /lib/modules/${KERNEL_VERSION}.el9_4.x86_64/extra/ \
-    && cp drivers/net/ethernet/intel/hl_cn/habanalabs_cn.ko /lib/modules/${KERNEL_VERSION}.el9_4.x86_64/extra/ \
-    && cp drivers/net/ethernet/intel/hl_en/habanalabs_en.ko /lib/modules/${KERNEL_VERSION}.el9_4.x86_64/extra/
+FROM ${BASEIMAGE}
 
-RUN depmod -a ${KERNEL_VERSION}
+ARG DRIVER_VERSION=1.16.1-7
+ARG EXTRA_RPM_PACKAGES=''
+
+COPY --from=builder /home/builder/usr/src/habanalabs-${DRIVER_VERSION}/drivers/accel/habanalabs/habanalabs.ko /tmp/extra/habanalabs.ko
+COPY --from=builder /home/builder/usr/src/habanalabs-${DRIVER_VERSION}/drivers/infiniband/hw/hbl/habanalabs_ib.ko /tmp/extra/habanalabs_ib.ko
+COPY --from=builder /home/builder/usr/src/habanalabs-${DRIVER_VERSION}/drivers/net/ethernet/intel/hbl_cn/habanalabs_cn.ko /tmp/extra/habanalabs_cn.ko
+COPY --from=builder /home/builder/usr/src/habanalabs-${DRIVER_VERSION}/drivers/net/ethernet/intel/hbl_en/habanalabs_en.ko /tmp/extra/habanalabs_en.ko
+COPY --from=builder /home/builder/lib/firmware/habanalabs /tmp/firmware/habanalabs
+
+RUN . /etc/os-release \
+    && export OS_VERSION_MAJOR=$(echo ${VERSION} | cut -d'.' -f 1) \
+    && export KERNEL_VERSION=$(rpm -q --qf '%{VERSION}-%{RELEASE}' kernel-core) \
+    && export TARGET_ARCH=$(rpm -q --qf '%{ARCH}' kernel-core) \
+    && mv /tmp/extra /lib/modules/${KERNEL_VERSION}.${TARGET_ARCH} \
+    && mv /tmp/firmware/habanalabs /lib/firmware \
+    && depmod -a ${KERNEL_VERSION}.${TARGET_ARCH}
+
+RUN dnf install -y rsync ${EXTRA_RPM_PACKAGES} \
+    && dnf clean all
 
 # Include growfs service
 COPY build/usr /usr
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-intel:latest"
 ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"
-
 
 ARG SSHPUBKEY
 

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -13,7 +13,6 @@ bootc: growfs prepare-files
 		$(EXTRA_RPM_PACKAGES:%=--build-arg EXTRA_RPM_PACKAGES=%) \
 		$(FROM:%=--build-arg BASEIMAGE=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \
-		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
 		$(VLLM_IMAGE:%=--build-arg VLLM_IMAGE=%) \
 		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \


### PR DESCRIPTION
The NVIDIA bootc container is using multi-stage to avoid shipping build dependencies in the final image, making it also smaller. This change implements the same build strategy for the Intel bootc image.

The builder image is the same as for NVIDIA bootc. It is currently named after NVIDIA, but should be renamed in a follow-up change. The benefit is that a single builder image is maintained for all bootc images that require out-of-tree drivers.

The number of build arguments is also reduced, since most of the information is already present in the builder image. There is only one kernel package per builder image and one image per architecture, so we can retrieve the `KERNEL_VERSION` and `TARGET_ARCH` variables by querying the RPM database. The OS information is retrieved by sourcing the `/etc/os-release` file.

The extraction of the RPMs doesn't require storing the files, as `rpm2cpio` supports streaming the file over HTTP(S). This number of commands is smaller and the downloads happened already for each build, since the download was not in a separate `RUN` statement.

It is not necessary to copy the source of the drivers in `/usr/src\, since we don't need to keep it in the final image. The Makefiles accept a `KVERSION` variable to specify the version of the kernel and resolve its path. The other benefit is to build as non-root.

The `.ko` files can then be copied to the final image with `COPY --from=builder`. The change also ensures that the firmware files are copied to the final image.

This change also adds support for `EXTRA_RPM_PACKAGES`.