### PR TITLE
Add note about Gaudi updates

### DIFF
--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -3,6 +3,9 @@ ARG BASEIMAGE="quay.io/centos-bootc/centos-bootc:stream9"
 
 FROM ${DRIVER_TOOLKIT_IMAGE} as builder
 
+# NOTE: The entire Gaudi stack from Kernel drivers to PyTorch and Instructlab
+# must be updated in lockstep. Please coordinate updateis with all
+# stakeholders.
 ARG DRIVER_VERSION=1.16.1-7
 ARG HABANA_REPO="https://vault.habana.ai/artifactory/rhel/9/9.2"
 


### PR DESCRIPTION
Any Gaudi update must be synchronized with all stakeholders. For now, all packages from Kernel OOT drivers over firmware and SynapseAI to PyTorch stack must have the same version. `habana-torch-plugin` version `1.16.0.526` does not work with Kernel drivers `1.16.1-7`.