### PR TITLE
Eliminate growfs from training containers

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -10,9 +10,6 @@ FROM ${BASEIMAGE}
 
 ADD rocm.repo /etc/yum.repos.d/rocm.repo
 
-# Include growfs service
-COPY build/usr /usr
-
 ARG EXTRA_RPM_PACKAGES=''
 RUN dnf install -y \
   pciutils \

--- a/training/amd-bootc/Makefile
+++ b/training/amd-bootc/Makefile
@@ -6,7 +6,7 @@ include ../common/Makefile.common
 default: bootc
 
 .PHONY: bootc
-bootc: prepare-files growfs
+bootc: prepare-files
 	"${CONTAINER_TOOL}" build \
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -78,11 +78,6 @@ check-umask:
 		(echo; echo -n "Error: umask $(UMASK) will cause unexpected behaviour: use umask 022! "; \
 		 echo "Verify the `ai-lab-recipes` git repository was cloned with umask 0022"; exit 1)
 
-.PHONY: growfs
-growfs: check-umask
-	# Add growfs service
-	mkdir -p build; cp -pR ../common/usr build
-
 .PHONY: bootc-image-builder
 bootc-image-builder:
 	mkdir -p build/store

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -48,9 +48,6 @@ RUN . /etc/os-release \
 RUN dnf install -y rsync ${EXTRA_RPM_PACKAGES} \
     && dnf clean all
 
-# Include growfs service
-COPY build/usr /usr
-
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-intel:latest"
 ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"
 

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -5,7 +5,7 @@ include ../common/Makefile.common
 default: bootc
 
 .PHONY: bootc
-bootc: growfs prepare-files
+bootc: prepare-files
 	${CONTAINER_TOOL} build \
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -22,9 +22,6 @@ USER builder
 WORKDIR /home/builder
 COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 
-# Include growfs service if needed
-RUN if [ -d "build/usr" ]; then cp -r build/usr /usr; fi
-
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
         NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
         && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -8,7 +8,7 @@ include ../common/Makefile.common
 default: bootc
 
 .PHONY: bootc
-bootc: driver-toolkit check-sshkey prepare-files growfs
+bootc: driver-toolkit check-sshkey prepare-files
 	"${CONTAINER_TOOL}" build \
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \


### PR DESCRIPTION
Training images will not be installed in the cloud by default so should not include growfs.