### PR TITLE
Fix image builder

### DIFF
--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -89,22 +89,22 @@ bootc-image-builder:
 	podman run \
 	  $(ARCH:%=--target-arch %) \
 	  $(AUTH_JSON:%=-v %:/run/containers/0/auth.json) \
-	  $(BOOTC_IMAGE_BUILDER) \
-	  $(IMAGE_BUILDER_CONFIG:%=--config /config$(suffix $(IMAGE_BUILDER_CONFIG))) \
-	  $(IMAGE_BUILDER_CONFIG:%=-v %:/config$(suffix $(IMAGE_BUILDER_CONFIG))) \
-	  ${CONTAINER_TOOL_EXTRA_ARGS} \
-	  ${IMAGE_BUILDER_EXTRA_ARGS} \
-	  --chown $(DISK_UID):$(DISK_GID) \
-	  --local \
+	  --rm \
+	  -ti \
 	  --privileged \
 	  --pull newer \
-	  --rm \
-	  --type $(DISK_TYPE) \
-	  -ti \
 	  -v $(GRAPH_ROOT):/var/lib/containers/storage \
 	  -v ./build/store:/store \
 	  -v ./build:/output \
-	  $(BOOTC_IMAGE)
+	  $(IMAGE_BUILDER_CONFIG:%=-v %:/config$(suffix $(IMAGE_BUILDER_CONFIG))) \
+	  ${CONTAINER_TOOL_EXTRA_ARGS} \
+	  $(BOOTC_IMAGE_BUILDER) \
+	    $(IMAGE_BUILDER_CONFIG:%=--config /config$(suffix $(IMAGE_BUILDER_CONFIG))) \
+	    ${IMAGE_BUILDER_EXTRA_ARGS} \
+	    --chown $(DISK_UID):$(DISK_GID) \
+	    --local \
+	    --type $(DISK_TYPE) \
+	    $(BOOTC_IMAGE)
 
 .PHONY: generate-model-cfile
 generate-model-cfile:

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -101,12 +101,11 @@ USER root
 COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /rpms/
 COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
 # Temporary workaround until the permanent fix for libdnf is merged
-RUN mv /etc/selinux /etc/selinux.tmp
-RUN dnf install -y /rpms/kmod-nvidia-*.rpm
-
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
 
-RUN if [ "${TARGET_ARCH}" == "" ]; then \
+RUN mv /etc/selinux /etc/selinux.tmp \
+    && dnf install -y /rpms/kmod-nvidia-*.rpm \
+    && if [ "${TARGET_ARCH}" == "" ]; then \
         export TARGET_ARCH="$(arch)" ;\
         fi \
     && if [ "${OS_VERSION_MAJOR}" == "" ]; then \


### PR DESCRIPTION
- Properly separate and order podman and bootc-image-builder arguments
- Move all the `selinux.tmp` workaround to the same layer, so bootc install wont complain about missing files