### PR TITLE
No longer using vllm and deepspeed images for AI bootc images

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -3,7 +3,7 @@ MAKEFLAGS += -j2
 default: help
 
 .PHONY: all
-all: deepspeed vllm models
+all: models
 
 help:
 	@echo "To build a bootable container image you first need to create instructlab container images for a particular vendor "
@@ -11,12 +11,6 @@ help:
 	@echo "  - make instruct-amd"
 	@echo "  - make instruct-intel"
 	@echo "  - make instruct-nvidia"
-	@echo "  - make instruct-vllm"
-	@echo
-	@echo "Once instruct images created, create advanced training containers, deepspeed only for nvidia"
-	@echo
-	@echo "  - make deepspeed"
-	@echo "  - make vllm"
 	@echo
 	@echo "Once instruct images are created, create bootc container images"
 	@echo
@@ -29,7 +23,6 @@ help:
 	@echo "  - make cloud-amd"
 	@echo "  - make cloud-intel"
 	@echo "  - make cloud-nvidia"
-	@echo "  - make cloud-vllm"
 	@echo
 	@echo "Make prune. This command will remove all buildah containers if left behind from podman build and then prune all unused container images. Useful if you are running out of space."
 	@echo
@@ -70,7 +63,7 @@ vllm:
 #
 # Create bootc container images prepared for AI
 #
-.PHONY: driver-tookit amd nvidia intel vllm
+.PHONY: driver-tookit amd nvidia intel
 driver-tookit:
 	make -C common/ -f Makefile.common driver-toolkit
 amd:

--- a/training/README.md
+++ b/training/README.md
@@ -53,7 +53,7 @@ Once you have these container images built it is time to build vllm.
 
 * make vllm
 
-# On nvidia systems, you need to build the deepspeed container
+# How to build the deepspeed deepspeed container
 
 * make deepspeed
 

--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -29,7 +29,6 @@ RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	cp /run/.input/ilab /usr/local/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-amd:latest"
-ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"
 
 ARG SSHPUBKEY
 
@@ -49,7 +48,5 @@ RUN sed -i "s%__REPLACE_CONTAINER_NAME__%${INSTRUCTLAB_IMAGE}%" /usr/local/bin/i
 VOLUME /var/lib/containers
 
 # Prepull the instructlab image
-RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/vllm) && \
-    podman --root /usr/lib/containers/storage image tag ${IID} ${VLLM_IMAGE}
 RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/instructlab-amd) && \
     podman --root /usr/lib/containers/storage image tag ${IID} ${INSTRUCTLAB_IMAGE}

--- a/training/amd-bootc/Makefile
+++ b/training/amd-bootc/Makefile
@@ -14,7 +14,6 @@ bootc: prepare-files growfs
 		$(FROM:%=--from=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(VLLM_IMAGE:%=--build-arg VLLM_IMAGE=%) \
 		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -32,8 +32,6 @@ DRIVER_VERSION ?=
 KERNEL_VERSION ?=
 
 INSTRUCTLAB_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/instructlab-$(VENDOR):$(IMAGE_TAG)
-VLLM_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/vllm:$(IMAGE_TAG)
-TRAIN_IMAGE = $(REGISTRY)/$(REGISTRY_ORG)/deepspeed-trainer:$(IMAGE_TAG)
 WRAPPER = $(CURDIR)/../ilab-wrapper/ilab
 QLORA_WRAPPER = $(CURDIR)/../ilab-wrapper/ilab-qlora
 TRAIN_WRAPPER =  $(CURDIR)/../ilab-wrapper/ilab-training-launcher

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -52,7 +52,6 @@ RUN dnf install -y rsync ${EXTRA_RPM_PACKAGES} \
 COPY build/usr /usr
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-intel:latest"
-ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"
 
 ARG SSHPUBKEY
 
@@ -65,7 +64,5 @@ RUN if [ -n "${SSHPUBKEY}" ]; then \
 fi
 
 # Prepull the instructlab image
-RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/vllm) && \
-    podman --root /usr/lib/containers/storage image tag ${IID} ${VLLM_IMAGE}
 RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/instructlab-intel) && \
     podman --root /usr/lib/containers/storage image tag ${IID} ${INSTRUCTLAB_IMAGE}

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -14,7 +14,6 @@ bootc: growfs prepare-files
 		$(FROM:%=--build-arg BASEIMAGE=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(VLLM_IMAGE:%=--build-arg VLLM_IMAGE=%) \
 		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -164,16 +164,12 @@ RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
 	cp /run/.input/ilab /usr/local/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
-ARG VLLM_IMAGE="quay.io/ai-lab/vllm:latest"
-ARG TRAIN_IMAGE="quay.io/ai-lab/deepspeed-trainer:latest"
 ARG GPU_COUNT_COMMAND="nvidia-ctk --quiet cdi list | grep -P nvidia.com/gpu='\\\\d+' | wc -l"
 
 RUN for i in /usr/local/bin/ilab*; do \
 	sed -i 's/__REPLACE_TRAIN_DEVICE__/cuda/' $i;  \
 	sed -i 's/__REPLACE_CONTAINER_DEVICE__/nvidia.com\/gpu=all/' $i; \
 	sed -i "s%__REPLACE_IMAGE_NAME__%${INSTRUCTLAB_IMAGE}%" $i; \
-	sed -i "s%__REPLACE_VLLM_NAME__%${VLLM_IMAGE}%" $i; \
-	sed -i "s%__REPLACE_TRAIN_NAME__%${TRAIN_IMAGE}%" $i; \
 	sed -i 's%__REPLACE_ENDPOINT_URL__%http://0.0.0.0:8080/v1%' $i; \
 	sed -i "s%__REPLACE_GPU_COUNT_COMMAND__%${GPU_COUNT_COMMAND}%" $i; \
 	sed -i 's/__REPLACE_TRAIN_DEVICE__/cuda/' $i; \
@@ -182,10 +178,6 @@ RUN for i in /usr/local/bin/ilab*; do \
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
 
-RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/vllm) && \
-    podman --root /usr/lib/containers/storage image tag ${IID} ${VLLM_IMAGE}
 RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/instructlab-nvidia) && \
     podman --root /usr/lib/containers/storage image tag ${IID} ${INSTRUCTLAB_IMAGE}
-RUN IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/deepspeed-trainer) && \
-    podman --root /usr/lib/containers/storage image tag ${IID} ${TRAIN_IMAGE}
 RUN podman system reset --force 2>/dev/null

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -22,8 +22,6 @@ bootc: driver-toolkit check-sshkey prepare-files growfs
 		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(OS_VERSION_MAJOR:%=--build-arg OS_VERSION_MAJOR=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(TRAIN_IMAGE:%=--build-arg TRAIN_IMAGE=%) \
-		$(VLLM_IMAGE:%=--build-arg VLLM_IMAGE=%) \
 		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \


### PR DESCRIPTION
Instructlab will include these executables inside of its container rather then using external containers.