### PR TITLE
make sure downloader image is present and called non short name

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -67,7 +67,7 @@ vllm:
 driver-tookit:
 	make -C common/ -f Makefile.common driver-toolkit
 amd:
-	make -C amd-bootc/ bootc bootc-models
+	make -C amd-bootc/ bootc download bootc-models
 intel:
 	make -C intel-bootc/ bootc bootc-models
 nvidia:

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -46,6 +46,8 @@ ENABLE_RT ?=
 
 SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub 2> /dev/null)
 
+include ../model/Makefile
+
  .PHONY: prepare-files
 prepare-files: $(OUTDIR)/$(WRAPPER) $(OUTDIR)/$(QLORA_WRAPPER) $(OUTDIR)/$(TRAIN_WRAPPER) $(OUTDIR)
 
@@ -103,7 +105,11 @@ bootc-image-builder:
 generate-model-cfile:
 	echo "FROM ${BOOTC_IMAGE}" > ${MODELS_CONTAINERFILE}
 	echo "RUN rsync -ah --progress --exclude '.hug*' --exclude '*.safetensors' /run/.input/models /usr/share" >> ${MODELS_CONTAINERFILE}
-	"${CONTAINER_TOOL}" run -v ../common:/work:z -v ${OUTDIR}:/run/.input:ro model-downloader:latest python3 /work/generate-model-cfile.py /run/.input/models >> ${MODELS_CONTAINERFILE}
+	"${CONTAINER_TOOL}" run \
+		-v ../common:/work:z \
+		-v ${OUTDIR}:/run/.input:ro \
+		--pull=never \
+		quay.io/ai-lab/model-downloader:local python3 /work/generate-model-cfile.py /run/.input/models >> ${MODELS_CONTAINERFILE}
 
 .PHONY: bootc-models
 bootc-models: generate-model-cfile

--- a/training/model/Makefile
+++ b/training/model/Makefile
@@ -10,8 +10,9 @@ default: download
 image:
 	"${CONTAINER_TOOL}" build \
 		--file Containerfile \
-		--tag model-downloader:latest \
+		--tag quay.io/ai-lab/model-downloader:local \
 		${CONTAINER_TOOL_EXTRA_ARGS} .
+		
 .PHONY: download
 download: image
 	$(MAKE) MODEL_REPO=$(GRANITE_MODEL_REPO) download-model
@@ -20,4 +21,8 @@ download: image
 .PHONY: download-model
 download-model:
 	mkdir -p ../build/models
-	podman run -e HF_TOKEN -v ../build/models:/download:z -t model-downloader huggingface-cli download --exclude "*.pt" --local-dir "/download/$(MODEL_REPO)" "$(MODEL_REPO)"
+	podman run -e HF_TOKEN \
+		-v ../build/models:/download:z \
+		-t quay.io/ai-lab/model-downloader:local \
+		--pull=never \
+		huggingface-cli download --exclude "*.pt" --local-dir "/download/$(MODEL_REPO)" "$(MODEL_REPO)"


### PR DESCRIPTION
Addresses: https://github.com/containers/ai-lab-recipes/issues/592
Please review @n1hility @rhatdan 
cc @cooktheryan @prarit

Change: model downloader is not present as well as short name resolution (not sure if this is a problem yet until it becomes available)