### PR TITLE
Remove --chown from bootc-image-builder

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -101,6 +101,8 @@ make cloud-intel
 bootc-image-builder produces disk images using a bootable container as input. Disk images can be used to directly provision a host
 The process will write the disk image in <platform>-bootc/build
 
+IMPORTANT: `osbuild-selinux` package needs to be installed for bootc-image-builder to work in a SELinux enabled host
+
 To invoke bootc-image-builder, execute make disk-<platform>
 ```
 make disk-nvidia

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -23,8 +23,6 @@ BUILD_ARG_FILE ?=
 IMAGE_BUILDER_CONFIG ?=
 IMAGE_BUILDER_EXTRA_ARGS ?=
 DISK_TYPE ?= qcow2
-DISK_UID ?= $(shell id -u)
-DISK_GID ?= $(shell id -g)
 
 ARCH ?=
 
@@ -94,7 +92,6 @@ bootc-image-builder:
 	  $(BOOTC_IMAGE_BUILDER) \
 	    $(IMAGE_BUILDER_CONFIG:%=--config /config$(suffix $(IMAGE_BUILDER_CONFIG))) \
 	    ${IMAGE_BUILDER_EXTRA_ARGS} \
-	    --chown $(DISK_UID):$(DISK_GID) \
 	    --local \
 	    --type $(DISK_TYPE) \
 	    $(BOOTC_IMAGE)


### PR DESCRIPTION
--chown tends to fail and makes the target exit with error

Also added a note about osbuild-selinux policies needed as a prerequisite