### PR TITLE
training/Makefile: Fix top level vendor targets

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -66,13 +66,14 @@ vllm:
 .PHONY: driver-tookit amd nvidia intel bootc-models
 driver-tookit:
 	make -C common/ -f Makefile.common driver-toolkit
-bootc-models:
-	make -C model/ bootc-models
-amd:  bootc-models
+amd:
+	make VENDOR=amd -C model/ bootc-models
 	make -C amd-bootc/ bootc
 intel: bootc-models
+	make VENDOR=intel -C model/ bootc-models
 	make -C intel-bootc/ bootc
 nvidia: bootc-models
+	make VENDOR=nvidia -C model/ bootc-models
 	make -C nvidia-bootc/ driver-toolkit bootc
 
 #


### PR DESCRIPTION
The top level vendor targets (amd, intel, nvidia) fail with

"podman" build \
	 \
	--file /root/ai-lab-recipes/training/model/../build/Containerfile.models \
	--security-opt label=disable \
	--tag "quay.io/ai-lab/-bootc-models:latest" \
	-v /root/ai-lab-recipes/training/model/../build:/run/.input:ro
Error: tag quay.io/ai-lab/-bootc-models:latest: invalid reference format make[1]: *** [Makefile:41: bootc-models] Error 125 make[1]: Leaving directory '/root/ai-lab-recipes/training/model' make: *** [Makefile:70: bootc-models] Error 2

because VENDOR is not defined when the bootc-models target is called.

Modify the makefile to set VENDOR for each target.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>