### PR TITLE
Change source from ilab wrapper

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -22,9 +22,10 @@ RUN dnf install -y \
 # Setup /usr/lib/containers/storage as an additional store for images.
 # Remove once the base images have this set by default.
 RUN sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
-	/etc/containers/storage.conf && \
-	cp /run/.input/ilab /usr/local/bin/ilab
+	/etc/containers/storage.conf 
 
+COPY ../ilab-wrapper/ilab /usr/local/bin/ilab
+ 	
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-amd:latest"
 
 ARG SSHPUBKEY

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -156,8 +156,9 @@ fi
 # Also make sure not to duplicate if a base image already has it specified.
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
-	/etc/containers/storage.conf && \
-	cp /run/.input/ilab /usr/local/bin/ilab
+	/etc/containers/storage.conf 
+
+COPY ../ilab-wrapper/ilab /usr/local/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG GPU_COUNT_COMMAND="nvidia-ctk --quiet cdi list | grep -P nvidia.com/gpu='\\\\d+' | wc -l"


### PR DESCRIPTION
Copying the `ilab` script from the image mount as it is done now breaks Konflux CI. If I'm not missing something we could get the same existing script from upper level and also that would ease CI tasks.
/cc @rhatdan @fabiendupont @Gregory-Pereira 