### PR TITLE
feat: adding support for hf_pretrained_model option

### DIFF
--- a/model_servers/llamacpp_python/src/requirements.txt
+++ b/model_servers/llamacpp_python/src/requirements.txt
@@ -1,2 +1,3 @@
 llama-cpp-python[server]==0.2.78
+transformers==4.41.2
 pip==24.0

--- a/model_servers/llamacpp_python/src/run.sh
+++ b/model_servers/llamacpp_python/src/run.sh
@@ -5,14 +5,20 @@ if [ ${CONFIG_PATH} ] || [[ ${MODEL_PATH} && ${CONFIG_PATH} ]]; then
 fi
 
 if [ ${MODEL_PATH} ]; then
-    python -m llama_cpp.server \
+    CMD="python -m llama_cpp.server \
         --model ${MODEL_PATH} \
         --host ${HOST:=0.0.0.0} \
         --port ${PORT:=8001} \
         --n_gpu_layers ${GPU_LAYERS:=0} \
         --clip_model_path ${CLIP_MODEL_PATH:=None} \
         --chat_format ${CHAT_FORMAT:=llama-2} \
-        --interrupt_requests ${INTERRUPT_REQUESTS:=False}
+        --interrupt_requests ${INTERRUPT_REQUESTS:=False}"
+
+    if [ ! -z "${HF_PRETRAINED_MODEL}" ] && [ "${HF_PRETRAINED_MODEL}" != "None" ]; then
+        CMD+=" --hf_pretrained_model_name_or_path ${HF_PRETRAINED_MODEL}"
+    fi
+
+    eval $CMD
     exit 0
 fi
 

--- a/model_servers/llamacpp_python/src/run.sh
+++ b/model_servers/llamacpp_python/src/run.sh
@@ -4,21 +4,21 @@ if [ ${CONFIG_PATH} ] || [[ ${MODEL_PATH} && ${CONFIG_PATH} ]]; then
     exit 0
 fi
 
+if [ "${HF_PRETRAINED_MODEL}" == "None" ]; then
+    HF_PRETRAINED_MODEL=""
+fi
+
 if [ ${MODEL_PATH} ]; then
-    CMD="python -m llama_cpp.server \
+    python -m llama_cpp.server \
         --model ${MODEL_PATH} \
         --host ${HOST:=0.0.0.0} \
         --port ${PORT:=8001} \
         --n_gpu_layers ${GPU_LAYERS:=0} \
         --clip_model_path ${CLIP_MODEL_PATH:=None} \
         --chat_format ${CHAT_FORMAT:=llama-2} \
-        --interrupt_requests ${INTERRUPT_REQUESTS:=False}"
-
-    if [ ! -z "${HF_PRETRAINED_MODEL}" ] && [ "${HF_PRETRAINED_MODEL}" != "None" ]; then
-        CMD+=" --hf_pretrained_model_name_or_path ${HF_PRETRAINED_MODEL}"
-    fi
-
-    eval $CMD
+        ${PRETRAINED_MODEL_PATH:=}
+        ${HF_PRETRAINED_MODEL:%=--hf_pretrained_model_name_or_path %} \
+        --interrupt_requests ${INTERRUPT_REQUESTS:=False}
     exit 0
 fi
 


### PR DESCRIPTION
## Description

Adding optional option `--hf_pretrained_model_name_or_path` through environment variable `HF_PRETRAINED_MODEL` easing the enablement for function calling[^2] 

## Related issue

Fixes https://github.com/containers/ai-lab-recipes/issues/601

[^2]: https://llama-cpp-python.readthedocs.io/en/latest/server/#function-calling