### PR TITLE
Workaround for ilab script source

### DIFF
--- a/.github/workflows/training_bootc.yaml
+++ b/.github/workflows/training_bootc.yaml
@@ -3,6 +3,24 @@ name: Training Bootc image builds
 on:
   workflow_dispatch:
 
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/training_bootc.yaml
+      - 'training/common/**'
+      - 'training/amd-bootc/**'
+      - 'training/intel-bootc/**'
+      - 'training/nvidia-bootc/**'
+      - 'training/intel-bootc/**'
+      - 'training/instructlab/**'
+      - 'training/vllm/**'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - .github/workflows/model_image_build_push.yaml
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -157,7 +157,7 @@ fi
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	/etc/containers/storage.conf && \
-	if [ -f /run/.input/ilab" ]; then \
+	if [ -f "/run/.input/ilab" ]; then \
 	  cp /run/.input/ilab /usr/local/bin/ilab \
         else \
 	  curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab" \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -99,7 +99,6 @@ COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /r
 COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
-COPY add_ilab_wrapper.sh add_ilab_wrapper.sh
 
 RUN mv /etc/selinux /etc/selinux.tmp \
     && dnf install -y /rpms/kmod-nvidia-*.rpm \
@@ -158,7 +157,11 @@ fi
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	/etc/containers/storage.conf && \
-	./add_ilab_wrapper.sh
+	if [ -f /run/.input/ilab" ]; then \
+	  cp /run/.input/ilab /usr/local/bin/ilab \
+        else \
+	  curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab" \
+        fi
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG GPU_COUNT_COMMAND="nvidia-ctk --quiet cdi list | grep -P nvidia.com/gpu='\\\\d+' | wc -l"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -160,7 +160,7 @@ RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
 	if [ -f "/run/.input/ilab" ]; then \
 	  cp /run/.input/ilab /usr/local/bin/ilab \
         else \
-	  curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab" \
+	  curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes/main/training/ilab-wrapper/ilab" \
         fi
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -99,6 +99,7 @@ COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /r
 COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
+COPY add_ilab_wrapper.sh add_ilab_wrapper.sh
 
 RUN mv /etc/selinux /etc/selinux.tmp \
     && dnf install -y /rpms/kmod-nvidia-*.rpm \
@@ -157,7 +158,8 @@ fi
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	/etc/containers/storage.conf && \
-	cp /run/.input/ilab /usr/local/bin/ilab
+	#cp /run/.input/ilab /usr/local/bin/ilab
+	./add_ilab_wrapper.sh
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG GPU_COUNT_COMMAND="nvidia-ctk --quiet cdi list | grep -P nvidia.com/gpu='\\\\d+' | wc -l"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -158,7 +158,6 @@ fi
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	/etc/containers/storage.conf && \
-	#cp /run/.input/ilab /usr/local/bin/ilab
 	./add_ilab_wrapper.sh
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"

--- a/training/nvidia-bootc/add_ilab_wrapper.sh
+++ b/training/nvidia-bootc/add_ilab_wrapper.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-LOCAL_ILAB_WRAPPER="run/.input/ilab"
-
-if [ -f "$LOCAL_ILAB_WRAPPER" ]; then
-	cp "$LOCAL_ILAB_WRAPPER" /usr/local/bin/ilab
-else
-	curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab"
-fi

--- a/training/nvidia-bootc/add_ilab_wrapper.sh
+++ b/training/nvidia-bootc/add_ilab_wrapper.sh
@@ -4,5 +4,5 @@ LOCAL_ILAB_WRAPPER="run/.input/ilab"
 if [ -f "$LOCAL_ILAB_WRAPPER" ]; then
 	cp "$LOCAL_ILAB_WRAPPER" /usr/local/bin/ilab
 else
-	curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/enriquebelarte/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab"
+	curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab"
 fi

--- a/training/nvidia-bootc/add_ilab_wrapper.sh
+++ b/training/nvidia-bootc/add_ilab_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+LOCAL_ILAB_WRAPPER="run/.input/ilab"
+
+if [ -f "$LOCAL_ILAB_WRAPPER" ]; then
+	cp "$LOCAL_ILAB_WRAPPER" /usr/local/bin/ilab
+else
+	curl -o /usr/local/bin/ilab "https://raw.githubusercontent.com/enriquebelarte/ai-lab-recipes-upstream/main/training/ilab-wrapper/ilab"
+fi


### PR DESCRIPTION
As [this](https://github.com/containers/ai-lab-recipes/pull/599) PR threw an [error](https://github.com/containers/ai-lab-recipes/pull/606) that prevented the build process, I propose this workaround that would make Konflux CI build pipeline work but also won't change the `make` behavior.

Suggestions, corrections accepted.
@n1hility @Gregory-Pereira 