### PR TITLE
Add note about osbuild-selinux required to build disk images

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -101,6 +101,8 @@ make cloud-intel
 bootc-image-builder produces disk images using a bootable container as input. Disk images can be used to directly provision a host
 The process will write the disk image in <platform>-bootc/build
 
+IMPORTANT: `osbuild-selinux` package needs to be installed for bootc-image-builder to work in a SELinux enabled host
+
 To invoke bootc-image-builder, execute make disk-<platform>
 ```
 make disk-nvidia


### PR DESCRIPTION
As explained in https://github.com/containers/ai-lab-recipes/pull/597#issuecomment-2186564414 the `osbuild-selinux` package is needed to build disk images

Since we're closing https://github.com/containers/ai-lab-recipes/pull/597 where I piggybacked this small README change, I'm creating this PR just for this small README addition

/cc @rhatdan 