### PR TITLE
Use --installed to get kernel version for packages to be installed

### DIFF
--- a/training/common/driver-toolkit/Containerfile
+++ b/training/common/driver-toolkit/Containerfile
@@ -8,9 +8,8 @@ ARG ENABLE_RT=''
 USER root
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
-        && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
+        RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info --installed kernel-core | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
         fi \
     && echo "${KERNEL_VERSION}" \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -23,9 +23,8 @@ WORKDIR /home/builder
 COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
-        && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
+        RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info --installed kernel-core | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
     fi \
     && if [ "${OS_VERSION_MAJOR}" == "" ]; then \


### PR DESCRIPTION
This fix should pin the kernel version to the one of the installed kernel-core package, which should always be the same one

This will solve when sometimes the modules are built for different versions, or other weird things:

```
[root@localhost modules]# find . | grep nvidia
./5.14.0-427.13.1.el9_4.x86_64/kernel/drivers/platform/x86/nvidia-wmi-ec-backlight.ko.xz
./5.14.0-427.22.1.el9_4.x86_64/extra/drivers/video/nvidia
./5.14.0-427.22.1.el9_4.x86_64/extra/drivers/video/nvidia/nvidia-drm.ko
```