### PR TITLE
fix: add build_vulkan commands for amd64/arm64 on Makefile

### DIFF
--- a/model_servers/llamacpp_python/Makefile
+++ b/model_servers/llamacpp_python/Makefile
@@ -19,9 +19,11 @@ all: build download-model-granite run
 build-cuda:
 	"${CONTAINER_TOOL}"  build --squash-all -t $(CUDA_IMAGE) . -f cuda/Containerfile
 
-.PHONY: build-vulkan
-build-vulkan:
-	"${CONTAINER_TOOL}"  build --squash-all -t $(VULKAN_IMAGE) . -f vulkan/Containerfile
+.PHONY: build-vulkan-amd64 build-vulkan-arm64
+build-vulkan-amd64:
+	"${CONTAINER_TOOL}"  build --squash-all -t $(VULKAN_IMAGE) . -f vulkan/amd64/Containerfile
+build-vulkan-arm64:
+	"${CONTAINER_TOOL}"  build --squash-all -t $(VULKAN_IMAGE) . -f vulkan/arm64/Containerfile
 
 .PHONY: download-model-granite # default model
 download-model-granite:

--- a/model_servers/llamacpp_python/README.md
+++ b/model_servers/llamacpp_python/README.md
@@ -61,9 +61,11 @@ The [Vulkan image](../llamacpp_python/vulkan/Containerfile) is experimental, but
 
 To build the Vulkan model service variant image:
 
-```bash
-make -f Makefile build-vulkan
-```
+| System Architecture | Command |
+|---|---|
+| amd64 | make -f Makefile build-vulkan-amd64 |
+| arm64 | make -f Makefile build-vulkan-arm64 |
+
 To pull the base model service image:
 
 ```bash


### PR DESCRIPTION
While playing with podman/libkrun/ai-lab I noticed that there was an error in the Makefile. There are 2 Containerfiles related to vulkan (amd64/arm64) but the Makefile was not targeting them.

This PR fixes it.