### PR TITLE
Add check for installed kernel-core

### DIFF
--- a/training/common/driver-toolkit/Containerfile
+++ b/training/common/driver-toolkit/Containerfile
@@ -7,7 +7,9 @@ ARG ENABLE_RT=''
 
 USER root
 
-RUN if [ "${KERNEL_VERSION}" == "" ]; then \
+RUN dnf -y update \
+    && dnf info --installed kernel > /dev/null || dnf install -y kernel-core \
+    && if [ "${KERNEL_VERSION}" == "" ]; then \
         RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
         && VERSION=$(dnf info --installed kernel-core | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\


### PR DESCRIPTION
Latest changes broke with some images that lack kernel-core package installed by default: i.e. ubi9.
Thanks @javipolo for your suggestion.