### PR TITLE
without the kernel-core package build fails

### DIFF
--- a/training/common/driver-toolkit/Containerfile
+++ b/training/common/driver-toolkit/Containerfile
@@ -8,7 +8,8 @@ ARG ENABLE_RT=''
 USER root
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        dnf -y install kernel-core \
+        && RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
         && VERSION=$(dnf info --installed kernel-core | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
         fi \


### PR DESCRIPTION
Currently testing is broken because the centos stream does not have the package that allows for the kernel version to be defined

https://github.com/containers/ai-lab-recipes/actions/runs/9681290098/job/26711665880