### PR TITLE
Exclude kernel packages from dnf update

### DIFF
--- a/training/common/driver-toolkit/Containerfile
+++ b/training/common/driver-toolkit/Containerfile
@@ -7,7 +7,7 @@ ARG ENABLE_RT=''
 
 USER root
 
-RUN dnf -y update \
+RUN dnf -y update --exclude kernel* \
     && dnf info --installed kernel > /dev/null || dnf install -y kernel-core \
     && if [ "${KERNEL_VERSION}" == "" ]; then \
         RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \


### PR DESCRIPTION
dnf update was there to update python3 packages because of CVE: https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?architecture=amd64&image=66610af1e7e2103fc98023b8&container-tabs=security

Also `dnf update` might install a newer kernel, leaving the container with two different kernels, thus the change 