### PR TITLE
Add libdnf workaround for intel-bootc

### DIFF
--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -45,11 +45,13 @@ RUN . /etc/os-release \
     && mv /tmp/firmware/habanalabs /lib/firmware \
     && depmod -a ${KERNEL_VERSION}.${TARGET_ARCH}
 
-RUN dnf install -y ${EXTRA_RPM_PACKAGES} \
+RUN mv /etc/selinux /etc/selinux.tmp \
+    && dnf install -y ${EXTRA_RPM_PACKAGES} \
     cloud-init \
     rsync \
     && dnf clean all \
-    && ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants
+    && ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants \
+    && mv /etc/selinux.tmp /etc/selinux 
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-intel:latest"
 


### PR DESCRIPTION
Same as in https://github.com/containers/ai-lab-recipes/pull/630 a workaround is applied in order to install needed packages with `dnf`