### PR TITLE
Remove training images from ailab-images.md

### DIFF
--- a/ailab-images.md
+++ b/ailab-images.md
@@ -16,11 +16,6 @@
 
 Images used in the `Bootc` aspect of this repo or tooling images
 
-- quay.io/ai-lab/nvidia-builder:latest
-- quay.io/ai-lab/instructlab-nvidia:latest
-- quay.io/ai-lab/nvidia-bootc:latest
-- quay.io/ai-lab/intel-bootc:latest
-- quay.io/ai-lab/amd-bootc:latest
 - quay.io/ai-lab/chromadb:latest
 - quay.io/ai-lab/model-converter:latest
 


### PR DESCRIPTION
We are not currently making these images available.

Fixes: https://github.com/containers/ai-lab-recipes/issues/643