### PR TITLE
Workaround hardlinked /etc changes

### DIFF
--- a/training/common/driver-toolkit/Containerfile
+++ b/training/common/driver-toolkit/Containerfile
@@ -7,6 +7,8 @@ ARG ENABLE_RT=''
 
 USER root
 
+# TODO: rework this monstrosity into a build.sh (or even not shell script)
+# The need for the `cp /etc/dnf/dnf.conf` is a workaround for https://github.com/containers/bootc/issues/637
 RUN dnf -y update --exclude kernel* \
     && dnf info --installed kernel > /dev/null || dnf install -y kernel-core \
     && if [ "${KERNEL_VERSION}" == "" ]; then \
@@ -16,6 +18,7 @@ RUN dnf -y update --exclude kernel* \
         fi \
     && echo "${KERNEL_VERSION}" \
     && dnf -y install dnf-plugin-config-manager \
+    && cp -a /etc/dnf/dnf.conf{,.tmp} && mv /etc/dnf/dnf.conf{.tmp,} \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
     && dnf -y install \
         kernel-devel-${KERNEL_VERSION} \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -99,6 +99,8 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
 
+# TODO: rework this monstrosity into a build.sh (or even not shell script)
+# The need for the `cp /etc/dnf/dnf.conf` is a workaround for https://github.com/containers/bootc/issues/637
 RUN mv /etc/selinux /etc/selinux.tmp \
     && dnf install -y /rpms/kmod-nvidia-*.rpm \
     && if [ "${TARGET_ARCH}" == "" ]; then \
@@ -113,6 +115,7 @@ RUN mv /etc/selinux /etc/selinux.tmp \
         CUDA_DASHED_VERSION=${CUDA_VERSION_ARRAY[0]}-${CUDA_VERSION_ARRAY[1]} \
         CUDA_REPO_ARCH=${TARGET_ARCH} \
     && if [ "${TARGET_ARCH}" == "aarch64" ]; then CUDA_REPO_ARCH="sbsa"; fi \
+    && cp -a /etc/dnf/dnf.conf{,.tmp} && mv /etc/dnf/dnf.conf{.tmp,} \
     && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
     && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel${OS_VERSION_MAJOR}/${CUDA_REPO_ARCH}/cuda-rhel${OS_VERSION_MAJOR}.repo \
     && dnf -y module enable nvidia-driver:${DRIVER_STREAM}/default \


### PR DESCRIPTION
This (not tested locally) change should work around https://github.com/containers/bootc/issues/637

It's all tricky because you'll only again see this when using the `vfs` backend. The `overlay` backend always breaks hardlinks. For more, see e.g. https://github.com/ostreedev/ostree-rs-ext/pull/408