### PR TITLE
Pull instructlab image with auth, if provided

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -182,9 +182,12 @@ RUN for i in /usr/local/bin/ilab*; do \
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.
 VOLUME /var/lib/containers
 
-RUN if [ -f "/run/.input/instructlab-nvidia/oci-layout" ]; then \
+RUN --mount=type=secret,id=instructlab-nvidia-pull/.dockerconfigjson \
+    if [ -f "/run/.input/instructlab-nvidia/oci-layout" ]; then \
          IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/instructlab-nvidia) && \
          podman --root /usr/lib/containers/storage image tag ${IID} ${INSTRUCTLAB_IMAGE}; \
+    elif [ -f "/run/secrets/instructlab-nvidia-pull/.dockerconfigjson" ]; then \
+         IID=$(sudo podman --root /usr/lib/containers/storage pull --authfile /run/secrets/instructlab-nvidia-pull/.dockerconfigjson ${INSTRUCTLAB_IMAGE}); \
     else \
          IID=$(sudo podman --root /usr/lib/containers/storage pull ${INSTRUCTLAB_IMAGE}); \
     fi


### PR DESCRIPTION
Upstream, this image can be pulled unauthenticated, but in other environments a user might want to include an image that exists in some repository that requires authentication to pull.

The person building the image needs to provide `--secret=id=instructlab-nvidia-pull/.dockerconfigjson,src=instructlab-nvidia-pull/.dockerconfigjson` when building the image in order to make the secret available.