### PR TITLE
RHELAI-473: Adding rhel ai version

### DIFF
--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -16,6 +16,7 @@ CONTAINER_TOOL_EXTRA_ARGS ?=
 EXTRA_RPM_PACKAGES ?=
 GRAPH_ROOT=$(shell podman info --format '{{ .Store.GraphRoot }}')
 UMASK=$(shell umask)
+IMAGE_VERSION := $(or ${IMAGE_VERSION},$(shell git rev-parse --short HEAD))
 
 AUTH_JSON ?=
 

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -99,6 +99,8 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
 
+ARG IMAGE_VERSION
+
 # TODO: rework this monstrosity into a build.sh (or even not shell script)
 # The need for the `cp /etc/dnf/dnf.conf` is a workaround for https://github.com/containers/bootc/issues/637
 RUN mv /etc/selinux /etc/selinux.tmp \
@@ -146,6 +148,9 @@ RUN mv /etc/selinux /etc/selinux.tmp \
     # Install rhc connect for insights telemetry gathering
     && . /etc/os-release && if [ "${ID}" == "rhel" ]; then \
         dnf install -y rhc rhc-worker-playbook; \
+        sed -i -e "/^VARIANT=/ {s/^VARIANT=.*/VARIANT=\"RHEL AI\"/; t}" -e "\$aVARIANT=\"RHEL AI\"\"" /etc/os-release;
+        sed -i -e "/^VARIANT_ID=/ {s/^VARIANT_ID=.*/VARIANT_ID=rhel_ai/; t}" -e "\$aVARIANT_ID=rhel_ai" /etc/os-release;
+        sed -i -e "/^BUILD_ID=/ {s/^BUILD_ID=.*/BUILD_ID='${IMAGE_VERSION}'/; t}" -e "\$aBUILD_ID='${IMAGE_VERSION}'" /etc/os-release;
         fi \
     && dnf clean all \
     && ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants \

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -16,6 +16,8 @@ bootc: driver-toolkit check-sshkey prepare-files
 		$(DRIVER_TOOLKIT_IMAGE:%=--build-arg DRIVER_TOOLKIT_IMAGE=%) \
 		$(DRIVER_VERSION:%=--build-arg DRIVER_VERSION=%) \
 		$(DRIVER_VERSION:%=--label driver-version=%) \
+		$(IMAGE_VERSION:%=--label image_version=%) \
+		$(IMAGE_VERSION:%=--build-arg IMAGE_VERSION=%) \
 		$(EXTRA_RPM_PACKAGES:%=--build-arg EXTRA_RPM_PACKAGES=%) \
 		$(FROM:%=--build-arg BASEIMAGE=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \


### PR DESCRIPTION
Adding rhel ai version
Set github hash by defautl as image version.
Add RHEL AI as variant into /etc/os-release in order to use it in insights

NAME="Red Hat Enterprise Linux"
VERSION="9.20240630.0.4 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.20240630.0.4 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.4
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
OSTREE_VERSION='9.20240630.0'
VARIANT_ID=rhel_ai1
VARIANT="RHEL AI"
BUILD_ID='v1.1.3'


