### PR TITLE
Fix SSH_PUBKEY expansion into build-arg

### DIFF
--- a/training/amd-bootc/Makefile
+++ b/training/amd-bootc/Makefile
@@ -14,7 +14,7 @@ bootc: prepare-files
 		$(FROM:%=--from=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
+		$(if $(SSH_PUBKEY),--build-arg SSHPUBKEY='$(SSH_PUBKEY)') \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \
 		--security-opt label=disable \

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -14,7 +14,7 @@ bootc: prepare-files
 		$(FROM:%=--build-arg BASEIMAGE=%) \
 		$(INSTRUCTLAB_IMAGE:%=--build-arg INSTRUCTLAB_IMAGE=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
+		$(if $(SSH_PUBKEY),--build-arg SSHPUBKEY='$(SSH_PUBKEY)') \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \
 		--security-opt label=disable \

--- a/training/nvidia-bootc/Makefile
+++ b/training/nvidia-bootc/Makefile
@@ -22,7 +22,7 @@ bootc: driver-toolkit check-sshkey prepare-files
 		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(OS_VERSION_MAJOR:%=--build-arg OS_VERSION_MAJOR=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
-		$(SSH_PUBKEY:%=--build-arg SSHPUBKEY=%) \
+		$(if $(SSH_PUBKEY),--build-arg SSHPUBKEY='$(SSH_PUBKEY)') \
 		--cap-add SYS_ADMIN \
 		--file Containerfile \
 		--security-opt label=disable \


### PR DESCRIPTION
Since ssh public key has spaces, it was expanded multiple times