### PR TITLE
WIP: Fork access

### DIFF
--- a/.github/workflows/training-e2e.yaml
+++ b/.github/workflows/training-e2e.yaml
@@ -27,6 +27,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  block-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from forked repo
+        id: check_forked
+        run: |
+          if [[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.event.pull_request.base.repo.full_name }} ]]; then
+            echo "This pull request was pushed from a forked repository, which is not allowed. Please push changes from a branch in the upstream repository"
+            exit 1
+          else
+            echo "This PR is from upstream repo."
+          fi
+
   check-membership:
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +68,7 @@ jobs:
   e2e:
     if: github.repository == 'containers/ai-lab-recipes' && !contains(github.event.pull_request.labels.*.name, 'hold-tests')
     runs-on: ubuntu-24.04
-    needs: check-membership
+    needs: [check-membership, block-pr]
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/training-e2e.yaml
+++ b/.github/workflows/training-e2e.yaml
@@ -1,17 +1,25 @@
 name: traning E2E
 
 on:
-  schedule: # schedule the job to run every day at midnight
-    - cron: '0 12 * * *'
-
-  pull_request:
-    branches:
-      - main
+  push:
+    branches: [ main ]
     paths:
-      - .github/workflows/training-e2e.yaml
-      - ./training/**
+      - 'training/**'
+      - '.github/workflows/training-e2e.yaml'
+
+  pull_request_target:
+    branches: [ main ]
+    paths:
+      - 'training/**'
+      - '.github/workflows/training_bootc.yaml'
 
   workflow_dispatch:
+
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
 
 env:
   TF_VAR_aws_region: "eu-west-2"
@@ -27,19 +35,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  block-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if PR is from forked repo
-        id: check_forked
-        run: |
-          if [[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.event.pull_request.base.repo.full_name }} ]]; then
-            echo "This pull request was pushed from a forked repository, which is not allowed. Please push changes from a branch in the upstream repository"
-            exit 1
-          else
-            echo "This PR is from upstream repo."
-          fi
-
   check-membership:
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +63,7 @@ jobs:
   e2e:
     if: github.repository == 'containers/ai-lab-recipes' && !contains(github.event.pull_request.labels.*.name, 'hold-tests')
     runs-on: ubuntu-24.04
-    needs: [check-membership, block-pr]
+    needs: [check-membership]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -82,7 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.7
         with:
-          path: main
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout terraform module
         id: checkout-module

--- a/.github/workflows/training-e2e.yaml
+++ b/.github/workflows/training-e2e.yaml
@@ -27,9 +27,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-membership:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user is a member of the organization
+        id: check_membership
+        run: |
+          ORG="your-organization"
+          USER=${{ github.actor }}
+          RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/orgs/containers/members/$USER")
+          if [[ "$RESPONSE" == *"Not Found"* ]]; then
+            echo "is_member=false" >> $GITHUB_ENV
+          else
+            echo "is_member=true" >> $GITHUB_ENV
+          fi
+
+      - name: Run main job if user is a member
+        if: env.is_member == 'true'
+        run: |
+          echo "User is a member of the organization. Running the job..."
+          # Add the steps of your main job here
+
+      - name: Skip job if user is not a member
+        if: env.is_member == 'false'
+        run: echo "User is not a member of the organization. Skipping the job."
+
   e2e:
     if: github.repository == 'containers/ai-lab-recipes' && !contains(github.event.pull_request.labels.*.name, 'hold-tests')
     runs-on: ubuntu-24.04
+    needs: check-membership
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/training_bootc.yaml
+++ b/.github/workflows/training_bootc.yaml
@@ -7,6 +7,12 @@ on:
       - 'training/**'
       - '.github/workflows/training_bootc.yaml'
 
+  pull_request_target:
+    branches: [ main ]
+    paths:
+      - 'training/**'
+      - '.github/workflows/training_bootc.yaml'
+
   workflow_dispatch:
 
 concurrency:
@@ -19,19 +25,6 @@ env:
   REGION: us-east-1
 
 jobs:
-  block-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if PR is from forked repo
-        id: check_forked
-        run: |
-          if [[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.event.pull_request.base.repo.full_name }} ]]; then
-            echo "This pull request was pushed from a forked repository, which is not allowed. Please push changes from a branch in the upstream repository"
-            exit 1
-          else
-            echo "This PR is from upstream repo."
-          fi
-
   check-membership:
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +52,7 @@ jobs:
 
   start-runner:
     name: Start self-hosted EC2 runner
-    needs: [ block-pr, check-membership ]
+    needs: [ check-membership ]
     if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     outputs:
@@ -98,6 +91,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: mkdir root/.docker directory
         run: |
@@ -159,6 +154,8 @@ jobs:
     needs: [ nvidia-bootc-builder-image, start-runner ]
     steps:
       - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: mkdir root/.docker directory
         run: |
@@ -222,6 +219,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: mkdir root/.docker directory
         run: |

--- a/.github/workflows/training_bootc.yaml
+++ b/.github/workflows/training_bootc.yaml
@@ -19,8 +19,47 @@ env:
   REGION: us-east-1
 
 jobs:
+  block-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from forked repo
+        id: check_forked
+        run: |
+          if [[ ${{ github.event.pull_request.head.repo.full_name }} != ${{ github.event.pull_request.base.repo.full_name }} ]]; then
+            echo "This pull request was pushed from a forked repository, which is not allowed. Please push changes from a branch in the upstream repository"
+            exit 1
+          else
+            echo "This PR is from upstream repo."
+          fi
+
+  check-membership:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user is a member of the organization
+        id: check_membership
+        run: |
+          ORG="your-organization"
+          USER=${{ github.actor }}
+          RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/orgs/containers/members/$USER")
+          if [[ "$RESPONSE" == *"Not Found"* ]]; then
+            echo "is_member=false" >> $GITHUB_ENV
+          else
+            echo "is_member=true" >> $GITHUB_ENV
+          fi
+
+      - name: Run main job if user is a member
+        if: env.is_member == 'true'
+        run: |
+          echo "User is a member of the organization. Running the job..."
+          # Add the steps of your main job here
+
+      - name: Skip job if user is not a member
+        if: env.is_member == 'false'
+        run: echo "User is not a member of the organization. Skipping the job."
+
   start-runner:
     name: Start self-hosted EC2 runner
+    needs: [ block-pr, check-membership ]
     if: "!contains(github.event.pull_request.labels.*.name, 'hold-tests')"
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/training_bootc.yaml
+++ b/.github/workflows/training_bootc.yaml
@@ -8,10 +8,6 @@ on:
       - '.github/workflows/training_bootc.yaml'
 
   pull_request_target:
-    branches: [ main ]
-    paths:
-      - 'training/**'
-      - '.github/workflows/training_bootc.yaml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
This should allow for forks to use secrets but first committers should not have access to run actions based on repo permissions. Next, we verify the user is a member of the container organization. If not we fail the run which would stop them from getting secrets.