### PR TITLE
Set group permissions on whispercpp app folder

### DIFF
--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -20,5 +20,9 @@ COPY --from=mwader/static-ffmpeg:6.1.1 /ffmpeg /bin/
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
 COPY src /app/
+
+RUN chgrp -R 0 /app && chmod -R g=u /app
+USER 1001
+
 ENV AUDIO_FILE=/app/jfk.wav
 ENTRYPOINT ["sh", "run.sh"]

--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -19,9 +19,8 @@ COPY --from=builder /app /app
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffmpeg /bin/
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
-COPY src /app/
+COPY --chown=0:0 --chmod=755 src /app
 
-RUN chgrp -R 0 /app && chmod -R g=u /app
 USER 1001
 
 ENV AUDIO_FILE=/app/jfk.wav


### PR DESCRIPTION
This PR updates the whispercpp dockerfile to mark the `/app` folder as owned by the GID 0, which is the group OpenShift uses. 

For some context, our team has been looking at consuming some of the Podman Desktop AI lab recipes via RHDH software templates, which will include OpenShift as a deployment target for the recipes. While trying to run the whispercpp model server, we found it was running into permissions issues when using the UID that OpenShift assigns to it (on the default, `restricted` SCC). Setting the user ID to `1001` and the group owner on the folder to `0` resolved these issues.

We've verified both locally and on OpenShift, let me know if this change is okay to go in. We also have an image built from this branch up at quay.io/redhat-ai-dev/whispercpp:latest