### PR TITLE
add skopeo so that ilab model download will work

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -22,6 +22,7 @@ RUN mv /etc/selinux /etc/selinux.tmp && \
   rocm-smi \
   tmux \
   rsync \
+  skopeo \
   ${EXTRA_RPM_PACKAGES} \
   && dnf clean all \
   && mv /etc/selinux.tmp /etc/selinux \

--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -51,6 +51,7 @@ RUN . /etc/os-release \
 
 RUN dnf install -y ${EXTRA_RPM_PACKAGES} \
     cloud-init \
+    skopeo \
     rsync \
     && dnf clean all \
     && ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -136,6 +136,7 @@ RUN mv /etc/selinux /etc/selinux.tmp \
         nvidia-persistenced-${DRIVER_VERSION} \
         nvidia-container-toolkit \
         rsync \
+	skopeo \
         ${EXTRA_RPM_PACKAGES} \
     && if [[ "$(rpm -qa | grep kernel-core | wc -l)" != "1" ]]; then \
         echo "ERROR - Multiple kernel-core packages detected"; \


### PR DESCRIPTION
While skopeo maybe part of the base image, there is no guarantee, and as long as ilab requires it, we should make sure it is installed.

Replaces: https://github.com/containers/ai-lab-recipes/pull/684
