### PR TITLE
RHELAI-429: Adding upgrade informer service

### DIFF
--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -52,7 +52,7 @@ ENABLE_RT ?=
 SSH_PUBKEY ?= $(shell cat ${HOME}/.ssh/id_rsa.pub 2> /dev/null)
 
 .PHONY: prepare-files
-prepare-files: $(OUTDIR)/$(WRAPPER) $(OUTDIR)/$(QLORA_WRAPPER) $(OUTDIR)/$(TRAIN_WRAPPER) $(OUTDIR)
+prepare-files: $(OUTDIR)/$(WRAPPER) $(OUTDIR)/$(QLORA_WRAPPER) $(OUTDIR)/$(TRAIN_WRAPPER) $(OUTDIR) common-services
 
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
@@ -62,6 +62,11 @@ $(OUTDIR)/$(QLORA_WRAPPER): $(OUTDIR)
 	cp -pf $(QLORA_WRAPPER) $(OUTDIR)
 $(OUTDIR)/$(TRAIN_WRAPPER): $(OUTDIR)
 	cp -pf $(TRAIN_WRAPPER) $(OUTDIR)
+
+.PHONY: common-services
+common-services:
+	mkdir -p build; cp -pR ../common/usr build
+
 
 .PHONY: check-sshkey
 check-sshkey:

--- a/training/common/usr/lib/systemd/system/basic.target.wants/upgrade-informer.service
+++ b/training/common/usr/lib/systemd/system/basic.target.wants/upgrade-informer.service
@@ -1,0 +1,1 @@
+../upgrade-informer.service

--- a/training/common/usr/lib/systemd/system/timers.target.wants/upgrade-informer.timer
+++ b/training/common/usr/lib/systemd/system/timers.target.wants/upgrade-informer.timer
@@ -1,0 +1,1 @@
+../upgrade-informer.timer

--- a/training/common/usr/lib/systemd/system/upgrade-informer.service
+++ b/training/common/usr/lib/systemd/system/upgrade-informer.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check for available RHEL AI upgrade
+ConditionPathExists=/run/ostree-booted
+After=network-online.target
+StartLimitIntervalSec=400
+StartLimitBurst=3
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/upgrade-informer
+Restart=on-failure
+RestartSec=90

--- a/training/common/usr/lib/systemd/system/upgrade-informer.timer
+++ b/training/common/usr/lib/systemd/system/upgrade-informer.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Runs upgrade informer periodically
+ConditionPathExists=/run/ostree-booted
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1day
+RandomizedDelaySec=2h
+
+[Install]
+WantedBy=timers.target

--- a/training/common/usr/libexec/upgrade-informer
+++ b/training/common/usr/libexec/upgrade-informer
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run the command and capture its output
+output=$(bootc upgrade --check | sed -e 1q)
+message_file="/etc/motd.d/upgrade-message"
+bootc_auth="/etc/ostree/auth.json"
+
+if [[ $output == Update\ available* ]]; then
+    if [[ ! -f $message_file ]]; then
+        echo "New version was found"
+        bootc_image=$(awk '{print $4}' <<< "$output")
+        # If auth file exists we should use it
+        auth_params=""
+        if [[ -f $bootc_auth ]]; then
+            auth_params="--authfile $bootc_auth"
+        fi
+
+        # Get image version
+        # shellcheck disable=SC2086
+        image_version_id=$(skopeo inspect --format json $auth_params "$bootc_image" | jq -r '.Labels | .["image_version_id"] // empty')
+
+        # If upgrade available, write the output to the file
+        cat > $message_file << EOF
+
+**   Attention!   **
+** A new $image_version_id version is available **
+** In order to apply it run: bootc upgrade --apply
+** Please note that the system will reboot after the upgrade **
+
+EOF
+    fi
+else
+    echo "No upgrade was found"
+    rm $message_file 2> /dev/null
+fi
+
+echo "Finished running upgrade informer"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -98,6 +98,8 @@ COPY --from=builder /home/builder/yum-packaging-precompiled-kmod/RPMS/*/*.rpm /r
 COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp/firmware/*.bin /lib/firmware/nvidia/${DRIVER_VERSION}/
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
+# Enable common services
+COPY build/usr /usr
 
 ARG IMAGE_VERSION_ID
 
@@ -145,9 +147,10 @@ RUN mv /etc/selinux /etc/selinux.tmp \
         dnf module enable -y nvidia-driver:${DRIVER_BRANCH} && \
         dnf install -y nvidia-fabric-manager-${DRIVER_VERSION} libnvidia-nscq-${DRIVER_BRANCH}-${DRIVER_VERSION} ; \
     fi \
-    # Install rhc connect for insights telemetry gathering
     && . /etc/os-release && if [ "${ID}" == "rhel" ]; then \
+        # Install rhc connect for insights telemetry gathering
         dnf install -y rhc rhc-worker-playbook; \
+        # Adding rhel ai identity to os-release file for insights usage
         sed -i -e "/^VARIANT=/ {s/^VARIANT=.*/VARIANT=\"RHEL AI\"/; t}" -e "\$aVARIANT=\"RHEL AI\"" /usr/lib/os-release; \
         sed -i -e "/^VARIANT_ID=/ {s/^VARIANT_ID=.*/VARIANT_ID=rhel_ai/; t}" -e "\$aVARIANT_ID=rhel_ai" /usr/lib/os-release; \
         sed -i -e "/^RHEL_AI_VERSION_ID=/ {s/^RHEL_AI_VERSION_ID=.*/RHEL_AI_VERSION_ID='${IMAGE_VERSION_ID}'/; t}" -e "\$aRHEL_AI_VERSION_ID='${IMAGE_VERSION_ID}'" /usr/lib/os-release; \


### PR DESCRIPTION
This is a duplication of https://github.com/containers/ai-lab-recipes/pull/663, since @tsorya is on PTO and we really need to push those changes

/cc @rhatdan 
/cc @jeremyeder

Upgrade informer will run every couple of our and will be triggered by systemd timer.

In order to start it on boot and run once i enabled it and timer. Disabling auto upgrade service in order to remove unexpected reboots. Service will run "bootc upgrade --check" and in case new version exists it will create motd file with upgrade info.