### PR TITLE
fix the photo upload issue in object detection app

### DIFF
--- a/recipes/computer_vision/object_detection/app/object_detection_client.py
+++ b/recipes/computer_vision/object_detection/app/object_detection_client.py
@@ -23,6 +23,8 @@ if image:
     window.image(img, use_column_width=True)  
     # convert PIL image into bytes for post request 
     bytes_io = io.BytesIO() 
+    if img.mode in ("RGBA", "P"): 
+        img = img.convert("RGB")
     img.save(bytes_io, "JPEG")
     img_bytes = bytes_io.getvalue()
     b64_image = base64.b64encode(img_bytes).decode('utf-8')


### PR DESCRIPTION
This PR is to fix the issue while uploading a photo:
```
cannot write mode RGBA as JPEG
```

JPG does not support transparency - RGBA means Red, Green, Blue, Alpha - Alpha is transparency.

The Image class has a method convert which can be used to convert RGBA to RGB - after that it will be able to save as JPG.