### PR TITLE
ilab wrapper: `exec` for better signal handling / termination

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -25,4 +25,4 @@ PODMAN_COMMAND=("podman" "run" "--rm" "-it"
 	"--env" "HF_TOKEN"
 	"${IMAGE_NAME}")
 
-"${PODMAN_COMMAND[@]}" "${PARAMS[@]}"
+exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"


### PR DESCRIPTION
If the wrapper script is killed, the container will be left running. Instead of just running the command, use `exec` to replace the wrapper script with the command, so that the command will receive the same signals as the wrapper script and the container will be terminated as expected.