### PR TITLE
Use custom systemd files and ilab wrapper from inside nvidia-bootc build context

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -104,7 +104,7 @@ COPY --from=builder --chmod=444 /home/builder/yum-packaging-precompiled-kmod/tmp
 # Temporary workaround until the permanent fix for libdnf is merged
 COPY nvidia-toolkit-firstboot.service /usr/lib/systemd/system/nvidia-toolkit-firstboot.service
 # Enable common services
-COPY build/usr /usr
+COPY duplicated/usr /usr
 
 ARG IMAGE_VERSION_ID
 
@@ -188,11 +188,7 @@ fi
 RUN grep -q /usr/lib/containers/storage /etc/containers/storage.conf || \
     sed -i -e '/additionalimage.*/a "/usr/lib/containers/storage",' \
 	/etc/containers/storage.conf && \
-    if [ -f "/run/.input/ilab" ]; then \
-	  cp /run/.input/ilab /usr/bin/ilab; \
-     else \
-	  curl -o /usr/bin/ilab "https://raw.githubusercontent.com/containers/ai-lab-recipes/main/training/ilab-wrapper/ilab"; \
-    fi \
+    cp duplicated/ilab-wrapper/ilab /usr/bin/ilab; \
     && chmod +x /usr/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"

--- a/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
+++ b/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Template values replaced by container build
+CONTAINER_DEVICE="__REPLACE_CONTAINER_DEVICE__"
+IMAGE_NAME="__REPLACE_IMAGE_NAME__"
+
+export ENTRYPOINT="/opt/python3.11/venv/bin/ilab"
+export PARAMS=("$@")
+
+for dir in "$HOME/.cache" "$HOME/.config" "$HOME/.local"; do
+	mkdir -p "$dir"
+done
+
+if [[ "$1" = "shell" ]]; then
+	export ENTRYPOINT=bash
+	export PARAMS=()
+fi
+
+PODMAN_COMMAND=("podman" "run" "--rm" "-it"
+	"--device" "${CONTAINER_DEVICE}"
+	"--security-opt" "label=disable" "--net" "host"
+	"-v" "$HOME:$HOME"
+        "--env" "HOME"
+	"--entrypoint" "$ENTRYPOINT"
+	"--env" "HF_TOKEN"
+	"${IMAGE_NAME}")
+
+exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"

--- a/training/nvidia-bootc/duplicated/usr/lib/systemd/system/basic.target.wants/upgrade-informer.service
+++ b/training/nvidia-bootc/duplicated/usr/lib/systemd/system/basic.target.wants/upgrade-informer.service
@@ -1,0 +1,1 @@
+../upgrade-informer.service

--- a/training/nvidia-bootc/duplicated/usr/lib/systemd/system/timers.target.wants/upgrade-informer.timer
+++ b/training/nvidia-bootc/duplicated/usr/lib/systemd/system/timers.target.wants/upgrade-informer.timer
@@ -1,0 +1,1 @@
+../upgrade-informer.timer

--- a/training/nvidia-bootc/duplicated/usr/lib/systemd/system/upgrade-informer.service
+++ b/training/nvidia-bootc/duplicated/usr/lib/systemd/system/upgrade-informer.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Check for available RHEL AI upgrade
+ConditionPathExists=/run/ostree-booted
+After=network-online.target
+StartLimitIntervalSec=400
+StartLimitBurst=3
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/upgrade-informer
+Restart=on-failure
+RestartSec=90

--- a/training/nvidia-bootc/duplicated/usr/lib/systemd/system/upgrade-informer.timer
+++ b/training/nvidia-bootc/duplicated/usr/lib/systemd/system/upgrade-informer.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Runs upgrade informer periodically
+ConditionPathExists=/run/ostree-booted
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1day
+RandomizedDelaySec=2h
+
+[Install]
+WantedBy=timers.target

--- a/training/nvidia-bootc/duplicated/usr/libexec/upgrade-informer
+++ b/training/nvidia-bootc/duplicated/usr/libexec/upgrade-informer
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Run the command and capture its output
+output=$(bootc upgrade --check | sed -e 1q)
+message_file="/etc/motd.d/upgrade-message"
+bootc_auth="/etc/ostree/auth.json"
+
+if [[ $output == Update\ available* ]]; then
+    if [[ ! -f $message_file ]]; then
+        echo "New version was found"
+        bootc_image=$(awk '{print $4}' <<< "$output")
+        # If auth file exists we should use it
+        auth_params=""
+        if [[ -f $bootc_auth ]]; then
+            auth_params="--authfile $bootc_auth"
+        fi
+
+        # Get image version
+        # shellcheck disable=SC2086
+        image_version_id=$(skopeo inspect --format json $auth_params "$bootc_image" | jq -r '.Labels | .["image_version_id"] // empty')
+
+        # If upgrade available, write the output to the file
+        cat > $message_file << EOF
+
+**   Attention!   **
+** A new $image_version_id version is available **
+** In order to apply it run: bootc upgrade --apply
+** Please note that the system will reboot after the upgrade **
+
+EOF
+    fi
+else
+    echo "No upgrade was found"
+    rm $message_file 2> /dev/null
+fi
+
+echo "Finished running upgrade informer"


### PR DESCRIPTION
In order to addres a problem with the build pipeline, we need all the files to be present inside of each container build context

Until we switch to have .. as the build context, we're duplicating some files