### PR TITLE
fix(modell_server): deprecated make arguments for llamacpp server

### DIFF
--- a/model_servers/llamacpp_python/cuda/Containerfile
+++ b/model_servers/llamacpp_python/cuda/Containerfile
@@ -4,7 +4,7 @@ RUN  dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
 USER 1001
 WORKDIR /locallm
 COPY src .
-ENV CMAKE_ARGS="-DLLAMA_CUBLAS=on -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF -DLLAMA_F16C=OFF"
+ENV CMAKE_ARGS="-DGGML_CUDA=1 -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF -DLLAMA_F16C=OFF"
 ENV FORCE_CMAKE=1
 RUN CC="/opt/rh/gcc-toolset-13/root/usr/bin/gcc" CXX="/opt/rh/gcc-toolset-13/root/usr/bin/g++" pip install --no-cache-dir -r ./requirements.txt
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/llamacpp_python/cuda/Containerfile
+++ b/model_servers/llamacpp_python/cuda/Containerfile
@@ -4,7 +4,7 @@ RUN  dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
 USER 1001
 WORKDIR /locallm
 COPY src .
-ENV CMAKE_ARGS="-DGGML_CUDA=1 -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF -DLLAMA_F16C=OFF"
+ENV CMAKE_ARGS="-DGGML_CUDA=on -DLLAMA_AVX2=OFF -DLLAMA_FMA=OFF -DLLAMA_F16C=OFF"
 ENV FORCE_CMAKE=1
 RUN CC="/opt/rh/gcc-toolset-13/root/usr/bin/gcc" CXX="/opt/rh/gcc-toolset-13/root/usr/bin/g++" pip install --no-cache-dir -r ./requirements.txt
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/model_servers/llamacpp_python/src/requirements.txt
+++ b/model_servers/llamacpp_python/src/requirements.txt
@@ -1,3 +1,3 @@
-llama-cpp-python[server]==0.2.82
-transformers==4.41.2
+llama-cpp-python[server]==0.2.84
+transformers==4.43.3
 pip==24.0

--- a/model_servers/llamacpp_python/src/requirements.txt
+++ b/model_servers/llamacpp_python/src/requirements.txt
@@ -1,3 +1,3 @@
-llama-cpp-python[server]==0.2.84
-transformers==4.43.3
+llama-cpp-python[server]==0.2.82
+transformers==4.41.2
 pip==24.0


### PR DESCRIPTION
The `LLAMA_CUBLAS` argument is deprecated

https://github.com/ggerganov/llama.cpp/blob/be20e7f49d9e5c6d9e8d9b4871eeba3df7a1639d/Makefile#L71-L72