### PR TITLE
ilab wrapper: add support for additional mounts

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -8,21 +8,42 @@ export ENTRYPOINT="/opt/python3.11/venv/bin/ilab"
 export PARAMS=("$@")
 
 for dir in "$HOME/.cache" "$HOME/.config" "$HOME/.local"; do
-    mkdir -p "$dir"
+	mkdir -p "$dir"
 done
 
 if [[ "$1" = "shell" ]]; then
-    export ENTRYPOINT=bash
-    export PARAMS=()
+	export ENTRYPOINT=bash
+	export PARAMS=()
 fi
 
+# If you need to mount additional volumes into the container, you can specify them
+# using the ILAB_ADDITIONAL_MOUNTS environment variable.
+#
+# Example ILAB_ADDITIONAL_MOUNTS usage:
+#
+# ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path /host/path2:/container/path2"
+#
+# If your path contains spaces, you can use quotes:
+#
+# ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path '/host/path with spaces':/container/path"
+ADDITIONAL_MOUNTS=()
+if [ -n "${ILAB_ADDITIONAL_MOUNTS}" ]; then
+	# (eval is used here to allow the user to specify mounts that might have spaces in them)
+	eval "ADDITIONAL_MOUNTS=(${ILAB_ADDITIONAL_MOUNTS})"
+fi
+ADDITIONAL_MOUNT_OPTIONS=()
+for PODMAN_MOUNT in "${ADDITIONAL_MOUNTS[@]}"; do
+	ADDITIONAL_MOUNT_OPTIONS+=("-v" "$PODMAN_MOUNT")
+done
+
 PODMAN_COMMAND=("podman" "run" "--rm" "-it"
-    "--device" "${CONTAINER_DEVICE}"
-    "--security-opt" "label=disable" "--net" "host"
-    "-v" "$HOME:$HOME"
-    "--env" "HOME"
-    "--entrypoint" "$ENTRYPOINT"
-    "--env" "HF_TOKEN"
-    "${IMAGE_NAME}")
+	"--device" "${CONTAINER_DEVICE}"
+	"--security-opt" "label=disable" "--net" "host"
+	"-v" "$HOME:$HOME"
+	"${ADDITIONAL_MOUNT_OPTIONS[@]}"
+	"--env" "HOME"
+	"--entrypoint" "$ENTRYPOINT"
+	"--env" "HF_TOKEN"
+	"${IMAGE_NAME}")
 
 exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"

--- a/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
+++ b/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
@@ -8,21 +8,42 @@ export ENTRYPOINT="/opt/python3.11/venv/bin/ilab"
 export PARAMS=("$@")
 
 for dir in "$HOME/.cache" "$HOME/.config" "$HOME/.local"; do
-    mkdir -p "$dir"
+	mkdir -p "$dir"
 done
 
 if [[ "$1" = "shell" ]]; then
-    export ENTRYPOINT=bash
-    export PARAMS=()
+	export ENTRYPOINT=bash
+	export PARAMS=()
 fi
 
+# If you need to mount additional volumes into the container, you can specify them
+# using the ILAB_ADDITIONAL_MOUNTS environment variable.
+#
+# Example ILAB_ADDITIONAL_MOUNTS usage:
+#
+# ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path /host/path2:/container/path2"
+#
+# If your path contains spaces, you can use quotes:
+#
+# ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path '/host/path with spaces':/container/path"
+ADDITIONAL_MOUNTS=()
+if [ -n "${ILAB_ADDITIONAL_MOUNTS}" ]; then
+	# (eval is used here to allow the user to specify mounts that might have spaces in them)
+	eval "ADDITIONAL_MOUNTS=(${ILAB_ADDITIONAL_MOUNTS})"
+fi
+ADDITIONAL_MOUNT_OPTIONS=()
+for PODMAN_MOUNT in "${ADDITIONAL_MOUNTS[@]}"; do
+	ADDITIONAL_MOUNT_OPTIONS+=("-v" "$PODMAN_MOUNT")
+done
+
 PODMAN_COMMAND=("podman" "run" "--rm" "-it"
-    "--device" "${CONTAINER_DEVICE}"
-    "--security-opt" "label=disable" "--net" "host"
-    "-v" "$HOME:$HOME"
-    "--env" "HOME"
-    "--entrypoint" "$ENTRYPOINT"
-    "--env" "HF_TOKEN"
-    "${IMAGE_NAME}")
+	"--device" "${CONTAINER_DEVICE}"
+	"--security-opt" "label=disable" "--net" "host"
+	"-v" "$HOME:$HOME"
+	"${ADDITIONAL_MOUNT_OPTIONS[@]}"
+	"--env" "HOME"
+	"--entrypoint" "$ENTRYPOINT"
+	"--env" "HF_TOKEN"
+	"${IMAGE_NAME}")
 
 exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"


### PR DESCRIPTION
Solves RHELAI-745

# Background

We have an ilab wrapper script that users will use to launch the ilab container.

Users may want to mount additional volumes into the container, as they could possibly have e.g. large models stored in some external storage.

# Problem

Users cannot simply edit the script to add the mounts to the podman command as it is read-only.

# Solution

Add support for an environment variable that users can set to specify additional mounts to be added to the podman command. This will allow users to specify additional mounts without having to modify the script.

# Implementation

The script will now check for the `ILAB_ADDITIONAL_MOUNTS` environment variable. If it is set, the script will parse the variable as evaluated bash code to get the mounts. The mounts will then be added to the podman command.

Example `ILAB_ADDITIONAL_MOUNTS` usage:

```bash
ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path /host/path2:/container/path2"`
```

If your path contains spaces, you can use quotes:

```bash
ILAB_ADDITIONAL_MOUNTS="/host/path:/container/path '/host/path with spaces':/container/path"
```

The latter works because the script uses `eval` to parse the mounts.