### PR TITLE
fix(model_server): missing prefix env

### DIFF
--- a/model_servers/llamacpp_python/src/run.sh
+++ b/model_servers/llamacpp_python/src/run.sh
@@ -4,8 +4,8 @@ if [ ${CONFIG_PATH} ] || [[ ${MODEL_PATH} && ${CONFIG_PATH} ]]; then
     exit 0
 fi
 
-if [ "${HF_PRETRAINED_MODEL}" == "None" ]; then
-    HF_PRETRAINED_MODEL=""
+if [ "${MODEL_HF_PRETRAINED_MODEL}" == "None" ]; then
+    MODEL_HF_PRETRAINED_MODEL=""
 fi
 
 if [ ${MODEL_PATH} ]; then
@@ -15,9 +15,9 @@ if [ ${MODEL_PATH} ]; then
         --port ${PORT:=8001} \
         --n_gpu_layers ${GPU_LAYERS:=0} \
         --clip_model_path ${CLIP_MODEL_PATH:=None} \
-        --chat_format ${CHAT_FORMAT:=llama-2} \
+        --chat_format ${MODEL_CHAT_FORMAT:=llama-2} \
         ${PRETRAINED_MODEL_PATH:=} \
-        ${HF_PRETRAINED_MODEL:+--hf_pretrained_model_name_or_path ${HF_PRETRAINED_MODEL}} \
+        ${MODEL_HF_PRETRAINED_MODEL:+--hf_pretrained_model_name_or_path ${MODEL_HF_PRETRAINED_MODEL}} \
         --interrupt_requests ${INTERRUPT_REQUESTS:=False}
     exit 0
 fi


### PR DESCRIPTION
In AI Lab we requires to have the `MODEL_` prefix for the chat format and the hf_pretrained_model_name_or_path

The prefix has been removed by mistake in https://github.com/containers/ai-lab-recipes/pull/531

In the documentation we are still showing the prefix. This PR restore it, to make AI Lab able to set the chat format and hf_pretrained_model_name_or_path

https://github.com/containers/ai-lab-recipes/blob/7409fdca6b01f2184e818cd15969b4eb3fac792a/model_servers/llamacpp_python/README.md?plain=1#L130