### PR TITLE
Set group permissions on the /rag/models/ dir

### DIFF
--- a/recipes/natural_language_processing/rag/app/Containerfile
+++ b/recipes/natural_language_processing/rag/app/Containerfile
@@ -19,4 +19,6 @@ COPY rag_app.py .
 COPY manage_vectordb.py .
 EXPOSE  8501
 ENV  HF_HUB_CACHE=/rag/models/
+RUN mkdir -p /rag/models/
+RUN chgrp -R 0 /rag/models/ && chmod -R g=u /rag/models/
 ENTRYPOINT [ "streamlit", "run" ,"rag_app.py" ]


### PR DESCRIPTION
Updates the RAG Containerfile for setting group permissions on the /rag/models/ dir.

We have been consuming the Podman Desktop AI lab recipes via RHDH [software templates](https://github.com/redhat-ai-dev/ai-lab-template/tree/main/templates), which will include OpenShift as a deployment target for the recipes. While trying to run the RAG application, we found it was running into permissions issues when using the UID that OpenShift assigns to the container. The fix has been verified both locally and on OpenShift.

Previously on OpenShift:
<img width="1430" alt="Screenshot 2024-08-01 at 6 13 47 PM" src="https://github.com/user-attachments/assets/fcd3775b-5693-48b9-907e-0da30917f7f3">