### PR TITLE
Add environment variables for ilab container and increase shm size for vllm

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -76,11 +76,15 @@ PODMAN_COMMAND=("sudo" "podman" "run" "--rm" "-it"
 	"${IMPERSONATE_CURRENT_USER_PODMAN_FLAGS[@]}"
 	"--device" "${CONTAINER_DEVICE}"
 	"--security-opt" "label=disable" "--net" "host"
+	"--shm-size" "10G"
 	"-v" "$HOME:$HOME"
 	"${ADDITIONAL_MOUNT_OPTIONS[@]}"
 	# This is intentionally NOT using "--env" "HOME" because we want the HOME
 	# of the current shell and not the HOME set by sudo
 	"--env" "HOME=$HOME"
+	"--env" "ILAB_GLOBAL_CONFIG=$ILAB_GLOBAL_CONFIG"
+	"--env" "VLLM_LOGGING_LEVEL=$VLLM_LOGGING_LEVEL"
+	"--env" "NCCL_DEBUG=$NCCL_DEBUG"
 	"--entrypoint" "$ENTRYPOINT"
 	"--env" "HF_TOKEN"
 	"${IMAGE_NAME}")


### PR DESCRIPTION
Include ILAB_GLOBAL_CONFIG, VLLM_LOGGING_LEVEL, and NCCL_DEBUG as environment variables when starting the ilab container. Also add shared memory size of 10G to enable vllm execution. Resolves: https://github.com/containers/ai-lab-recipes/issues/721