### PR TITLE
feat(KONFLUX-3933): Use rpm to get the value

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -23,8 +23,8 @@ WORKDIR /home/builder
 COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        RELEASE=$(dnf info --installed kernel-core | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info --installed kernel-core | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
+        RELEASE=$(rpm -q kernel-core --qf="%{RELEASE}") \
+        && VERSION=$(rpm -q kernel-core --qf="%{VERSION}") \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
     fi \
     && if [ "${OS_VERSION_MAJOR}" == "" ]; then \


### PR DESCRIPTION
This might be a more straight-forward way how to get a kernel version and release.

Initially I thought there will be a run duration benefit (running whole `dnf` vs. just `rpm`), but that is not a case (at least in this `builder` container).