### PR TITLE
ilab-wrapper: don't map UIDs if we're already running as root

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -60,23 +60,30 @@ fi
 # In the future, we will run podman as the current user, once we figure a
 # reasonable way for the current user to access the root's user container
 # storage.
-CURRENT_USER_NAME=$(id --user --name)
-CURRENT_USER_SUBUID_RANGE=$(awk \
-    --field-separator ':' \
-    --assign current_user="$CURRENT_USER_NAME" \
-    --assign current_uid="$UID" \
-    '$1 == current_user || $1 == current_uid {print $2 ":" $3}' \
-    /etc/subuid)
+if [[ "$UID" == 0 ]]; then
+    # If we're already running as root, we don't need to map any UIDs
+    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=()
+else
+    CURRENT_USER_NAME=$(id --user --name)
+    CURRENT_USER_SUBUID_RANGE=$(awk \
+        --field-separator ':' \
+        --assign current_user="$CURRENT_USER_NAME" \
+        --assign current_uid="$UID" \
+        '$1 == current_user || $1 == current_uid {print $2 ":" $3}' \
+        /etc/subuid)
 
-# TODO: Handle multiple subuid ranges, for now, hard fail
-if [[ $(wc -l <<<"$CURRENT_USER_SUBUID_RANGE") != 1 ]]; then
-    if [[ -z "$CURRENT_USER_SUBUID_RANGE" ]]; then
-        echo-err "No subuid range found for user $CURRENT_USER_NAME ($UID)"
-    else
-        echo-err "Multiple subuid ranges found for user $CURRENT_USER_NAME ($UID), this is currently unsupported"
-        echo-err "$CURRENT_USER_SUBUID_RANGE"
+    # TODO: Handle multiple subuid ranges, for now, hard fail
+    if [[ $(wc -l <<<"$CURRENT_USER_SUBUID_RANGE") != 1 ]]; then
+        if [[ -z "$CURRENT_USER_SUBUID_RANGE" ]]; then
+            echo-err "No subuid range found for user $CURRENT_USER_NAME ($UID)"
+        else
+            echo-err "Multiple subuid ranges found for user $CURRENT_USER_NAME ($UID), this is currently unsupported"
+            echo-err "$CURRENT_USER_SUBUID_RANGE"
+        fi
+        exit 1
     fi
-    exit 1
+
+    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=("--uidmap" "0:$UID" "--uidmap" "1:$CURRENT_USER_SUBUID_RANGE")
 fi
 
 IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=("--uidmap" "0:$UID" "--uidmap" "1:$CURRENT_USER_SUBUID_RANGE")


### PR DESCRIPTION
# Background

See df8885777d2257a6271ca1a6461673d1d96e99d6

# Issue

Introduced a regression [1] where it's no longer possible to run the script as root, as the subuid map ends up being empty and this causes an error:

```
Error: invalid empty host id at UID map: [1  1]
```

# Solution

Avoid UID mapping if we're already running as root.

# Motivation

We want to also be able to run the script as root, for example as part of a systemd service.

[1] RHELAI-798