### PR TITLE
Fix NVIDIA FabricManager unit file

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -168,7 +168,7 @@ RUN mv /etc/selinux /etc/selinux.tmp \
     && mv /etc/selinux.tmp /etc/selinux \
     && ln -s /usr/lib/systemd/system/nvidia-toolkit-firstboot.service /usr/lib/systemd/system/basic.target.wants/nvidia-toolkit-firstboot.service \
     && echo "blacklist nouveau" > /etc/modprobe.d/blacklist_nouveau.conf \
-    && sed '/\[Unit\]/a ConditionPathExists = /dev/nvidia-nvswitchctl' /usr/lib/systemd/system/nvidia-fabricmanager.service \
+    && sed -i '/\[Unit\]/a ConditionPathExists = /dev/nvidia-nvswitchctl' /usr/lib/systemd/system/nvidia-fabricmanager.service \
     && ln -s /usr/lib/systemd/system/nvidia-fabricmanager.service /etc/systemd/system/multi-user.target.wants/nvidia-fabricmanager.service \
     && ln -s /usr/lib/systemd/system/nvidia-persistenced.service /etc/systemd/system/multi-user.target.wants/nvidia-persistenced.service
 


### PR DESCRIPTION
In the `nvidia-bootc` Containerfile, the condition on the existence of `/dev/nvswitchctl` in the `nvidia-fabricmanager` unit file is not persisted, because we don't use the `-i` option of `sed`, so the final image still always tries to load the service. This change adds the `-i` option to fix this.