### PR TITLE
Driver Toolkit: Get kernel version from bootc image

### DIFF
--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -31,10 +31,10 @@ DISK_TYPE ?= qcow2
 DISK_UID ?= $(shell id -u)
 DISK_GID ?= $(shell id -g)
 
-ARCH ?=
+ARCH ?= $(shell arch)
 
 DRIVER_VERSION ?=
-KERNEL_VERSION ?=
+KERNEL_VERSION ?= $(shell skopeo inspect --format json docker://${FROM} | jq -r '.Labels["ostree.linux"]' | sed "s/\.${ARCH}//")
 
 INSTRUCTLAB_IMAGE ?= $(REGISTRY)/$(REGISTRY_ORG)/instructlab-$(HARDWARE):$(IMAGE_TAG)
 WRAPPER = $(CURDIR)/../ilab-wrapper/ilab
@@ -43,8 +43,9 @@ TRAIN_WRAPPER =  $(CURDIR)/../ilab-wrapper/ilab-training-launcher
 OUTDIR = $(CURDIR)/../build
 MODELS_CONTAINERFILE = $(OUTDIR)/Containerfile.models
 
+DRIVER_TOOLKIT_BASE_IMAGE ?=
 DRIVER_TOOLKIT_IMAGE_NAME ?= driver-toolkit
-DRIVER_TOOLKIT_IMAGE_TAG ?= latest
+DRIVER_TOOLKIT_IMAGE_TAG ?= ${KERNEL_VERSION}
 DRIVER_TOOLKIT_IMAGE ?= ${REGISTRY}/${REGISTRY_ORG}/${DRIVER_TOOLKIT_IMAGE_NAME}:${DRIVER_TOOLKIT_IMAGE_TAG}
 
 ENABLE_RT ?=
@@ -113,7 +114,7 @@ driver-toolkit:
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \
 		$(ENABLE_RT:%=--build-arg ENABLE_RC=%) \
-		$(FROM:%=--from=%) \
+		$(DRIVER_TOOLKIT_BASE_IMAGE:%=--build-arg BASEIMAGE=%) \
 		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \
 		--file ../common/driver-toolkit/Containerfile \

--- a/training/intel-bootc/Makefile
+++ b/training/intel-bootc/Makefile
@@ -9,6 +9,7 @@ bootc: prepare-files
 	${CONTAINER_TOOL} build \
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \
+                $(DRIVER_TOOLKIT_IMAGE:%=--build-arg DRIVER_TOOLKIT_IMAGE=%) \
 		$(DRIVER_VERSION:%=--build-arg DRIVER_VERSION=%) \
 		$(EXTRA_RPM_PACKAGES:%=--build-arg EXTRA_RPM_PACKAGES=%) \
 		$(FROM:%=--build-arg BASEIMAGE=%) \

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -22,7 +22,7 @@ COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 RUN export KVER=$(rpm -q --qf "%{VERSION}" kernel-core) \
         KREL=$(rpm -q --qf "%{RELEASE}" kernel-core | sed 's/\.el.\(_.\)*$//') \
         KDIST=$(rpm -q --qf "%{RELEASE}" kernel-core | awk -F '.' '{ print "."$NF}') \
-        OS_VERSION_MAJOR=$(grep "^VERSION=" /etc/os-release | cut -d '=' -f 2 | sed 's/"//g') \
+        OS_VERSION_MAJOR=$(grep "^VERSION=" /etc/os-release | cut -d '=' -f 2 | sed 's/"//g' | cut -d '.' -f 1) \
     && if [ "${BUILD_ARCH}" == "" ]; then \
         export BUILD_ARCH=$(arch) \
         && export TARGET_ARCH=$(echo "${BUILD_ARCH}" | sed 's/+64k//') ;\
@@ -93,7 +93,7 @@ ARG IMAGE_VERSION_ID
 # The need for the `cp /etc/dnf/dnf.conf` is a workaround for https://github.com/containers/bootc/issues/637
 RUN mv /etc/selinux /etc/selinux.tmp \
     && dnf install -y /rpms/kmod-nvidia-*.rpm \
-    && export OS_VERSION_MAJOR=$(grep "^VERSION=" /etc/os-release | cut -d '=' -f 2 | sed 's/"//g') \
+    && export OS_VERSION_MAJOR=$(grep "^VERSION=" /etc/os-release | cut -d '=' -f 2 | sed 's/"//g' | cut -d '.' -f 1) \
     && if [ "${TARGET_ARCH}" == "" ]; then \
         export TARGET_ARCH="$(arch)" ;\
     fi \


### PR DESCRIPTION
Driver Toolkit: Get kernel version from bootc image

When building the `driver-toolkit` image, It is cumbersome to find kernel
version that matches the future `nvidia-bootc` and `intel-bootc` images.
However, the kernel version is stored as a label on the `rhel-bootc`
images, which are exposed as the `FROM` variable in the Makefile.

This change collects the kernel version using `skopeo inspect` and `jq`.

The `DRIVER_TOOLKIT_BASE_IMAGE` variable is introduced in the Makefile
to dissociate it from the `FROM` variable that is used as the `nvidia-bootc`
and `intel-bootc` base image.

The user can now specify something like:

```shell
make nvidia-bootc \
    FROM=quay.io/centos-bootc/centos-bootc:stream9 \
    DRIVER_TOOLKIT_BASE_IMAGE=quay.io/centos/centos:stream9
```

Also, the `VERSION` variable in `/etc/os-release` is the full version, so
this change modifies the command to retrieve the `OS_VERSION_MAJOR`
value.

Signed-off-by: Fabien Dupont <fdupont@redhat.com>