### PR TITLE
Intel bootc - Update Gaudi drivers to 1.17.0-495

### DIFF
--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -6,8 +6,8 @@ FROM ${DRIVER_TOOLKIT_IMAGE} as builder
 # NOTE: The entire Gaudi stack from Kernel drivers to PyTorch and Instructlab
 # must be updated in lockstep. Please coordinate updates with all
 # stakeholders.
-ARG DRIVER_VERSION=1.16.1-7
-ARG HABANA_REPO="https://vault.habana.ai/artifactory/rhel/9/9.2"
+ARG DRIVER_VERSION=1.17.0-495
+ARG HABANA_REPO="https://vault.habana.ai/artifactory/rhel/9/9.4"
 
 WORKDIR /home/builder
 
@@ -28,7 +28,7 @@ RUN . /etc/os-release \
 
 FROM ${BASEIMAGE}
 
-ARG DRIVER_VERSION=1.16.1-7
+ARG DRIVER_VERSION=1.17.0-495
 ARG EXTRA_RPM_PACKAGES=''
 
 ARG VENDOR=''


### PR DESCRIPTION
Intel has released the version `1.17.0-495` of their Gaudi drivers. They
are available explicitly for RHEL 9.4 with a new `9.4` folder in the RPM
repository. This change updates the arguments to use the new version
from the new repository folder.
    
Signed-off-by: Fabien Dupont <fdupont@redhat.com>
