### PR TITLE
fix: fix image name on chatbot ai-lab.yaml

### DIFF
--- a/recipes/natural_language_processing/chatbot/ai-lab.yaml
+++ b/recipes/natural_language_processing/chatbot/ai-lab.yaml
@@ -15,7 +15,7 @@ application:
         - amd64
       ports:
         - 8001
-      image: quay.io/ai-lab/llamacppp_python:latest
+      image: quay.io/ai-lab/llamacpp_python:latest
     - name: streamlit-chat-app
       contextdir: app
       containerfile: Containerfile


### PR DESCRIPTION
It fixes the image name on the chatbot ai-lab.yaml. It should be `llamacpp_python:latest`