### PR TITLE
fix(whispercpp): adding missing ownership to user 1001 in app directory

### DIFF
--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -19,7 +19,8 @@ COPY --from=builder /app /app
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffmpeg /bin/
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
-COPY --chown=1001:0 --chmod=755 src /app
+COPY --chown=0:0 --chmod=755 src /app
+RUN chown 1001:1001 /app
 
 USER 1001
 

--- a/model_servers/whispercpp/base/Containerfile
+++ b/model_servers/whispercpp/base/Containerfile
@@ -19,7 +19,7 @@ COPY --from=builder /app /app
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffmpeg /bin/
 COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /bin/
 
-COPY --chown=0:0 --chmod=755 src /app
+COPY --chown=1001:0 --chmod=755 src /app
 
 USER 1001
 


### PR DESCRIPTION
Fixes https://github.com/containers/ai-lab-recipes/issues/743

The user 1001 needs permission to write to the /app directory as it creates a temp file in the current directory.

See https://github.com/ggerganov/whisper.cpp/blob/fe36c909715e6751277ddb020e7892c7670b61d4/examples/server/server.cpp#L680 for ref