### PR TITLE
chore: tag model_servers images on release

### DIFF
--- a/.github/workflows/model_servers.yaml
+++ b/.github/workflows/model_servers.yaml
@@ -15,6 +15,8 @@ on:
       - 'model_servers/**'
       - 'models/Makefile'
       - .github/workflows/model_servers.yaml
+    tags:
+      - '*'
 
   workflow_dispatch:
 
@@ -97,7 +99,7 @@ jobs:
         with:
           image: ${{ env.REGISTRY }}/${{ github.repository_owner}}/${{ matrix.image_name }}
           platforms: ${{ matrix.platforms }}
-          tags: latest
+          tags: latest ${{ github.ref_type == 'tag' && github.ref_name || '' }}
           containerfiles: ./model_servers/${{ matrix.directory }}/${{ matrix.flavor }}/Containerfile
           context: model_servers/${{ matrix.directory }}/
 


### PR DESCRIPTION
This PR tag the container images of the model_servers with the `ref_name` if one is provided.

Fixes https://github.com/containers/ai-lab-recipes/issues/748

According to the redhat-actions/buildah-build documentation, the tags should be separated with white spaces[^1]


[^1]: https://github.com/marketplace/actions/buildah-build#image-and-tags-inputs