### PR TITLE
Configure model for the rag recipe

### DIFF
--- a/recipes/natural_language_processing/rag/app/rag_app.py
+++ b/recipes/natural_language_processing/rag/app/rag_app.py
@@ -12,6 +12,7 @@ import os
 
 model_service = os.getenv("MODEL_ENDPOINT","http://0.0.0.0:8001")
 model_service = f"{model_service}/v1"
+model_name = os.getenv("MODEL_NAME", "") 
 chunk_size = os.getenv("CHUNK_SIZE", 150)
 embedding_model = os.getenv("EMBEDDING_MODEL","BAAI/bge-base-en-v1.5")
 vdb_vendor = os.getenv("VECTORDB_VENDOR", "chromadb")
@@ -75,6 +76,7 @@ for msg in st.session_state.messages:
 
 llm = ChatOpenAI(base_url=model_service, 
                  api_key="EMPTY",
+                 model=model_name,
                  streaming=True,
                  callbacks=[StreamlitCallbackHandler(st.container(),
                                                      collapse_completed_thoughts=True)])


### PR DESCRIPTION
Make the same changes like https://github.com/containers/ai-lab-recipes/pull/519 for the rag recipe to allow model name, this lets us use the vLLM model servers on OpenShift with GPUs

Before:
<img width="1426" alt="Screenshot 2024-08-08 at 6 44 29 PM" src="https://github.com/user-attachments/assets/92f87f60-2392-4f98-b22b-0f1d4b5cc67c">

After:
<img width="1440" alt="Screenshot 2024-08-08 at 7 08 06 PM" src="https://github.com/user-attachments/assets/dc7d3748-e7fc-470e-aa4d-2651007cac8a">
