### PR TITLE
Remove retagging from ilab image

### DIFF
--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -172,7 +172,6 @@ RUN chmod +x /usr/bin/ilab
 
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG INSTRUCTLAB_IMAGE_PULL_SECRET="instructlab-nvidia-pull"
-ARG INSTRUCTLAB_IMAGE_RETAG
 
 RUN for i in /usr/bin/ilab*; do \
 	sed -i 's/__REPLACE_TRAIN_DEVICE__/cuda/' $i;  \
@@ -191,10 +190,6 @@ RUN --mount=type=secret,id=${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson \
          IID=$(sudo podman --root /usr/lib/containers/storage pull --authfile /run/secrets/${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson ${INSTRUCTLAB_IMAGE}); \
     else \
          IID=$(sudo podman --root /usr/lib/containers/storage pull ${INSTRUCTLAB_IMAGE}); \
-    fi
-
-RUN if [ ! -z "${INSTRUCTLAB_IMAGE_RETAG}" ]; then \
-        podman tag ${INSTRUCTLAB_IMAGE} ${INSTRUCTLAB_IMAGE%%:*}:${INSTRUCTLAB_IMAGE_RETAG}; \
     fi
 
 RUN podman system reset --force 2>/dev/null


### PR DESCRIPTION
Retag is not needed as we are using static tags now.