### PR TITLE
RHELAI-969: Revert "Fix long container startup times"

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -49,8 +49,7 @@ check_insights
 
 # Template values replaced by container build
 CONTAINER_DEVICE="__REPLACE_CONTAINER_DEVICE__"
-SOURCE_IMAGE="__REPLACE_IMAGE_NAME__"
-IMAGE_NAME="localhost/instructlab:__REPLACE_IMAGE_TAG__"
+IMAGE_NAME="__REPLACE_IMAGE_NAME__"
 
 ENTRYPOINT="ilab"
 PARAMS=("$@")
@@ -144,13 +143,5 @@ PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it
     "--entrypoint" "$ENTRYPOINT"
     "--env" "HF_TOKEN"
     "${IMAGE_NAME}")
-
-sudo podman image exists "$IMAGE_NAME"
-if [ "$?" != "0" ]; then
-   echo "Initializing ilab container..."
-   id=$(sudo podman create "$SOURCE_IMAGE")
-   sudo podman commit "$id" "$IMAGE_NAME"
-   sudo podman rm "$id"
-fi
 
 exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -173,12 +173,10 @@ RUN chmod +x /usr/bin/ilab
 ARG INSTRUCTLAB_IMAGE="quay.io/ai-lab/instructlab-nvidia:latest"
 ARG INSTRUCTLAB_IMAGE_PULL_SECRET="instructlab-nvidia-pull"
 
-RUN export INSTRUCTLAB_TAG=$(echo ${INSTRUCTLAB_IMAGE} | cut -f 2 -d ':') && \
-    for i in /usr/bin/ilab*; do \
+RUN for i in /usr/bin/ilab*; do \
 	sed -i 's/__REPLACE_TRAIN_DEVICE__/cuda/' $i;  \
 	sed -i 's/__REPLACE_CONTAINER_DEVICE__/nvidia.com\/gpu=all/' $i; \
 	sed -i "s%__REPLACE_IMAGE_NAME__%${INSTRUCTLAB_IMAGE}%" $i; \
-	sed -i "s%__REPLACE_IMAGE_TAG__%${INSTRUCTLAB_TAG}%" $i; \
     done
 
 # Added for running as an OCI Container to prevent Overlay on Overlay issues.

--- a/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
+++ b/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
@@ -49,8 +49,7 @@ check_insights
 
 # Template values replaced by container build
 CONTAINER_DEVICE="__REPLACE_CONTAINER_DEVICE__"
-SOURCE_IMAGE="__REPLACE_IMAGE_NAME__"
-IMAGE_NAME="localhost/instructlab:__REPLACE_IMAGE_TAG__"
+IMAGE_NAME="__REPLACE_IMAGE_NAME__"
 
 ENTRYPOINT="ilab"
 PARAMS=("$@")
@@ -144,13 +143,5 @@ PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it
     "--entrypoint" "$ENTRYPOINT"
     "--env" "HF_TOKEN"
     "${IMAGE_NAME}")
-
-sudo podman image exists "$IMAGE_NAME"
-if [ "$?" != "0" ]; then
-   echo "Initializing ilab container..."
-   id=$(sudo podman create "$SOURCE_IMAGE")
-   sudo podman commit "$id" "$IMAGE_NAME"
-   sudo podman rm "$id"
-fi
 
 exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"


### PR DESCRIPTION
This reverts commit 2f2d608f71d82c433e7016199b9d5ab69466d50f.

We're reverting because `ilab wrapper` fails when running `podman commit`, as it tries to write in /usr/lib/containers/storage container-storage, which is read-only:

```
Error: copying layers and metadata for container "4f45cf68b00c7dcce075f1fb784435accd1db1b725281d9baef3e1e4af1c400b": initializing source containers-storage:reverent_maxwell: extracting layer "05bbf1431815e7eceec338385e6bc33036661c66a7f702fd23898d9b0c85811e": unmounting layer 9e50616152e3b65bd1764bc87294cbd44869020820007dfc454dc4606485e8c3: removing mount point "/usr/lib/containers/storage/overlay/9e50616152e3b65bd1764bc87294cbd44869020820007dfc454dc4606485e8c3/merged": read-only file system
```

/cc @fabiendupont 
/cc @kwozyman 
/cc @n1hility 