### PR TITLE
Share the additional container storage

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -2,22 +2,6 @@
 
 echo-err() { echo "$@" >&2; }
 
-verify_range() {
-    subuid_range="$1"
-    username="$2"
-    NUMBER_OF_MATCHING_SUBUID_RANGES=$(if [[ -z "$subuid_range" ]]; then echo 0; else wc -l <<<"$subuid_range"; fi)
-
-    if [[ "$NUMBER_OF_MATCHING_SUBUID_RANGES" == 0 ]]; then
-        echo-err "No /etc/subuid range found for user $username ($UID)"
-        exit 1
-    elif [[ "$NUMBER_OF_MATCHING_SUBUID_RANGES" != 1 ]]; then
-        # TODO: Handle multiple subuid ranges. But for now, hard fail
-        echo-err "Multiple /etc/subuid ranges found for user $username ($UID), this is currently unsupported:"
-        echo-err "$subuid_range"
-        exit 1
-    fi
-}
-
 check_insights() {
     if [[ -f /etc/insights-client/machine-id ]]; then
         return
@@ -100,35 +84,7 @@ do
     fi
 done
 
-# We run the container as sudo in order to be able to access the root container
-# storage, which has the ilab image pre-pulled. But for security reasons we map
-# root UID 0 inside the container to the current user's UID (and all the other
-# subuids to the user's /etc/subuid range) so that we're effectively running
-# the container as the current user.
-#
-# In the future, we will run podman as the current user, once we figure a
-# reasonable way for the current user to access the root's user container
-# storage.
-if [[ "$UID" == 0 ]]; then
-    # If we're already running as root, we don't need to map any UIDs
-    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=()
-else
-    CURRENT_USER_NAME=$(id --user --name)
-    CURRENT_USER_SUBUID_RANGE=$(awk \
-        --field-separator ':' \
-        --assign current_user="$CURRENT_USER_NAME" \
-        --assign current_uid="$UID" \
-        '$1 == current_user || $1 == current_uid {print $2 ":" $3}' \
-        /etc/subuid)
-
-    verify_range "$CURRENT_USER_SUBUID_RANGE" "$CURRENT_USER_NAME"
-
-    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=("--uidmap" "0:$UID" "--uidmap" "1:$CURRENT_USER_SUBUID_RANGE")
-fi
-
-PRESERVE_ENV="SSL_CERT_FILE,SSL_CERT_DIR,VLLM_LOGGING_LEVEL,NCCL_DEBUG,HOME,HF_TOKEN"
-PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it"
-    "${IMPERSONATE_CURRENT_USER_PODMAN_FLAGS[@]}"
+PODMAN_COMMAND=("podman" "run" "--rm" "-it"
     "--device" "${CONTAINER_DEVICE}"
     "--security-opt" "label=disable" "--net" "host"
     "--shm-size" "10G"

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -187,12 +187,15 @@ VOLUME /var/lib/containers
 RUN --mount=type=secret,id=${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson \
     if [ -f "/run/.input/instructlab-nvidia/oci-layout" ]; then \
          IID=$(podman --root /usr/lib/containers/storage pull oci:/run/.input/instructlab-nvidia) && \
-         podman --root /usr/lib/containers/storage image tag ${IID} ${INSTRUCTLAB_IMAGE}; \
+         podman --root /usr/lib/containers/storage --storage-opt overlay.force_mask=shared image tag ${IID} ${INSTRUCTLAB_IMAGE}; \
     elif [ -f "/run/secrets/${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson" ]; then \
-         IID=$(sudo podman --root /usr/lib/containers/storage pull --authfile /run/secrets/${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson ${INSTRUCTLAB_IMAGE}); \
+         IID=$(sudo podman --root /usr/lib/containers/storage pull --storage-opt overlay.force_mask=shared --authfile /run/secrets/${INSTRUCTLAB_IMAGE_PULL_SECRET}/.dockerconfigjson ${INSTRUCTLAB_IMAGE}); \
     else \
-         IID=$(sudo podman --root /usr/lib/containers/storage pull ${INSTRUCTLAB_IMAGE}); \
-    fi
+         IID=$(sudo podman --root /usr/lib/containers/storage --storage-opt overlay.force_mask=shared pull ${INSTRUCTLAB_IMAGE}); \
+    fi && \
+    chmod -R a+rX /usr/lib/containers
+
+COPY containers-storage.conf /etc/skel/.config/containers/storage.conf
 
 RUN podman system reset --force 2>/dev/null
 

--- a/training/nvidia-bootc/containers-storage.conf
+++ b/training/nvidia-bootc/containers-storage.conf
@@ -1,0 +1,17 @@
+[storage]
+driver = "overlay"
+
+[storage.options]
+size = ""
+remap-uids = ""
+remap-gids = ""
+ignore_chown_errors = ""
+remap-user = ""
+remap-group = ""
+skip_mount_home = ""
+mount_program = "/usr/bin/fuse-overlayfs"
+mountopt = ""
+additionalimagestores = [ "/usr/lib/containers/storage",]
+
+[storage.options.overlay]
+force_mask = "shared"

--- a/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
+++ b/training/nvidia-bootc/duplicated/ilab-wrapper/ilab
@@ -2,22 +2,6 @@
 
 echo-err() { echo "$@" >&2; }
 
-verify_range() {
-    subuid_range="$1"
-    username="$2"
-    NUMBER_OF_MATCHING_SUBUID_RANGES=$(if [[ -z "$subuid_range" ]]; then echo 0; else wc -l <<<"$subuid_range"; fi)
-
-    if [[ "$NUMBER_OF_MATCHING_SUBUID_RANGES" == 0 ]]; then
-        echo-err "No /etc/subuid range found for user $username ($UID)"
-        exit 1
-    elif [[ "$NUMBER_OF_MATCHING_SUBUID_RANGES" != 1 ]]; then
-        # TODO: Handle multiple subuid ranges. But for now, hard fail
-        echo-err "Multiple /etc/subuid ranges found for user $username ($UID), this is currently unsupported:"
-        echo-err "$subuid_range"
-        exit 1
-    fi
-}
-
 check_insights() {
     if [[ -f /etc/insights-client/machine-id ]]; then
         return
@@ -100,35 +84,7 @@ do
     fi
 done
 
-# We run the container as sudo in order to be able to access the root container
-# storage, which has the ilab image pre-pulled. But for security reasons we map
-# root UID 0 inside the container to the current user's UID (and all the other
-# subuids to the user's /etc/subuid range) so that we're effectively running
-# the container as the current user.
-#
-# In the future, we will run podman as the current user, once we figure a
-# reasonable way for the current user to access the root's user container
-# storage.
-if [[ "$UID" == 0 ]]; then
-    # If we're already running as root, we don't need to map any UIDs
-    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=()
-else
-    CURRENT_USER_NAME=$(id --user --name)
-    CURRENT_USER_SUBUID_RANGE=$(awk \
-        --field-separator ':' \
-        --assign current_user="$CURRENT_USER_NAME" \
-        --assign current_uid="$UID" \
-        '$1 == current_user || $1 == current_uid {print $2 ":" $3}' \
-        /etc/subuid)
-
-    verify_range "$CURRENT_USER_SUBUID_RANGE" "$CURRENT_USER_NAME"
-
-    IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=("--uidmap" "0:$UID" "--uidmap" "1:$CURRENT_USER_SUBUID_RANGE")
-fi
-
-PRESERVE_ENV="VLLM_LOGGING_LEVEL,NCCL_DEBUG,HOME,HF_TOKEN"
-PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it"
-    "${IMPERSONATE_CURRENT_USER_PODMAN_FLAGS[@]}"
+PODMAN_COMMAND=("podman" "run" "--rm" "-it"
     "--device" "${CONTAINER_DEVICE}"
     "--security-opt" "label=disable" "--net" "host"
     "--shm-size" "10G"


### PR DESCRIPTION
We need to share container image storage between rootless users, so that
we don't need `sudo` and we don't duplicate the `instructlab` image.
This change follows the Red Hat solution to
[create additional image store for rootless users](https://access.redhat.com/solutions/6206192).

The `/usr/lib/containers/storage` folder can be read by anyone and new
users will inherit a default configuration via `/etc/skel` that
configures the additional storage.

The `ilab` wrapper is also modified to remove the impersonation code and
not use `sudo` anymore.