### PR TITLE
Update amd-bootc to AMD ROCm 6.2

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -34,9 +34,9 @@ COPY repos.d/RPM-GPG-KEY-AMD-ROCM /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM \
     && mv /etc/selinux /etc/selinux.tmp \ 
     && dnf install -y \
+        amd-smi \
         cloud-init \
         pciutils \
-        rocm-smi \
         rsync \
         skopeo \
         tmux \

--- a/training/amd-bootc/repos.d/amdgpu.repo
+++ b/training/amd-bootc/repos.d/amdgpu.repo
@@ -1,6 +1,6 @@
 [amdgpu]
 name=amdgpu
-baseurl=https://repo.radeon.com/amdgpu/6.1.2/el/9.4/main/x86_64/
+baseurl=https://repo.radeon.com/amdgpu/6.2/el/9.4/main/x86_64/
 enabled=1
 priority=50
 gpgcheck=1

--- a/training/amd-bootc/repos.d/rocm.repo
+++ b/training/amd-bootc/repos.d/rocm.repo
@@ -1,6 +1,6 @@
 [ROCm-6.2]
 name=ROCm6.2
-baseurl=https://repo.radeon.com/rocm/el9/6.1.2/main
+baseurl=https://repo.radeon.com/rocm/el9/6.2/main
 enabled=1
 priority=50
 gpgcheck=1


### PR DESCRIPTION
This change updates the version of AMD ROCm to 6.2 in the amd-bootc image for training. With this new version, the `rocm-smi` package is replaced by the `amd-smi` package.

/cc @prarit 