### PR TITLE
Remove already present symlinks for cloud services

### DIFF
--- a/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
+++ b/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-config.service

--- a/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
+++ b/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-final.service

--- a/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
+++ b/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init-local.service

--- a/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
+++ b/training/cloud/aws/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init.service

--- a/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
+++ b/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-config.service

--- a/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
+++ b/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-final.service

--- a/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
+++ b/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init-local.service

--- a/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
+++ b/training/cloud/azure/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init.service

--- a/training/cloud/gcp/files/etc/systemd/system/NetworkManager.service.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/NetworkManager.service.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-osconfig-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-osconfig-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-osconfig-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-shutdown-scripts.service
+++ b/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-shutdown-scripts.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-shutdown-scripts.service

--- a/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-startup-scripts.service
+++ b/training/cloud/gcp/files/etc/systemd/system/multi-user.target.wants/google-startup-scripts.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-startup-scripts.service

--- a/training/cloud/gcp/files/etc/systemd/system/network.service.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/network.service.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/networking.service.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/networking.service.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/sshd.service.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/sshd.service.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/systemd-networkd.service.wants/google-guest-agent.service
+++ b/training/cloud/gcp/files/etc/systemd/system/systemd-networkd.service.wants/google-guest-agent.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-guest-agent.service

--- a/training/cloud/gcp/files/etc/systemd/system/timers.target.wants/google-oslogin-cache.timer
+++ b/training/cloud/gcp/files/etc/systemd/system/timers.target.wants/google-oslogin-cache.timer
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/google-oslogin-cache.timer

--- a/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
+++ b/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-config.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-config.service

--- a/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
+++ b/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-final.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-final.service

--- a/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
+++ b/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-init-local.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init-local.service

--- a/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
+++ b/training/cloud/ibm/files/etc/systemd/system/cloud-init.target.wants/cloud-init.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/cloud-init.service


### PR DESCRIPTION
All those symlinks are already present after rpm installation, so there is no need to add them