### PR TITLE
Update environment preservation for Podman with python https ca control variables

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -126,7 +126,7 @@ else
     IMPERSONATE_CURRENT_USER_PODMAN_FLAGS=("--uidmap" "0:$UID" "--uidmap" "1:$CURRENT_USER_SUBUID_RANGE")
 fi
 
-PRESERVE_ENV="VLLM_LOGGING_LEVEL,NCCL_DEBUG,HOME,HF_TOKEN"
+PRESERVE_ENV="SSL_CERT_FILE,SSL_CERT_DIR,VLLM_LOGGING_LEVEL,NCCL_DEBUG,HOME,HF_TOKEN"
 PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it"
     "${IMPERSONATE_CURRENT_USER_PODMAN_FLAGS[@]}"
     "--device" "${CONTAINER_DEVICE}"
@@ -140,6 +140,8 @@ PODMAN_COMMAND=("sudo" "--preserve-env=$PRESERVE_ENV" "podman" "run" "--rm" "-it
     "--env" "NCCL_DEBUG"
     "--entrypoint" "$ENTRYPOINT"
     "--env" "HF_TOKEN"
+    "--env" "SSL_CERT_FILE"
+    "--env" "SSL_CERT_DIR"
     "${IMAGE_NAME}")
 
 exec "${PODMAN_COMMAND[@]}" "${PARAMS[@]}"


### PR DESCRIPTION
Add SSL_CERT_FILE and SSL_CERT_DIR to the preserved environment variables and ensure they are passed to Podman. This change ensures that SSL certificates are correctly handled within the container environment. 

Provides path for sdg to interact with teacher models with certificates issued from private CAs (https://github.com/instructlab/sdg/pull/106). 