### PR TITLE
driver-toolkit make target fixes.

### DIFF
--- a/training/Makefile
+++ b/training/Makefile
@@ -63,7 +63,7 @@ vllm:
 # Create bootc container images prepared for AI
 #
 .PHONY: driver-tookit amd-bootc nvidia-bootc intel-bootc
-driver-tookit:
+driver-toolkit:
 	$(MAKE) -C common/ -f Makefile.common driver-toolkit
 amd-bootc:
 	$(MAKE) -C amd-bootc/ bootc

--- a/training/common/Makefile.common
+++ b/training/common/Makefile.common
@@ -114,6 +114,7 @@ driver-toolkit:
 		$(ARCH:%=--platform linux/%) \
 		$(BUILD_ARG_FILE:%=--build-arg-file=%) \
 		$(ENABLE_RT:%=--build-arg ENABLE_RC=%) \
+		$(FROM:%=--build-arg BASEIMAGE=%) \
 		$(DRIVER_TOOLKIT_BASE_IMAGE:%=--build-arg BASEIMAGE=%) \
 		$(KERNEL_VERSION:%=--build-arg KERNEL_VERSION=%) \
 		$(SOURCE_DATE_EPOCH:%=--timestamp=%) \


### PR DESCRIPTION
Added `BASEIMAGE` argument to driver-toolkit make target and fixed a target name typo.