### PR TITLE
Add Bearer (token) authentication support to recipes

### DIFF
--- a/recipes/audio/audio_to_text/app/whisper_client.py
+++ b/recipes/audio/audio_to_text/app/whisper_client.py
@@ -8,13 +8,17 @@ st.title(":studio_microphone: Speech Recognition")
 st.markdown("Upload an audio file you wish to have translated")
 endpoint = os.getenv("MODEL_ENDPOINT", default="http://0.0.0.0:8001")
 endpoint = f"{endpoint}/inference"
+endpoint_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
+request_kwargs = {}
+if endpoint_bearer is not None:
+    request_kwargs["headers"] = {"Authorization": f"Bearer {endpoint_bearer}"}
 audio = st.file_uploader("", type=["wav","mp3","mp4","flac"], accept_multiple_files=False)
 # read audio file
 if audio:
     audio_bytes = audio.read()
     st.audio(audio_bytes, format='audio/wav', start_time=0)
-    files = {'file': audio_bytes}
-    response = requests.post(endpoint, files=files)
+    request_kwargs["files"] = {'file': audio_bytes}
+    response = requests.post(endpoint, **request_kwargs)
     response_json = response.json()
     st.subheader(f"Translated Text")
     st.text_area(label="", value=response_json['text'], height=300)

--- a/recipes/computer_vision/object_detection/app/object_detection_client.py
+++ b/recipes/computer_vision/object_detection/app/object_detection_client.py
@@ -7,8 +7,11 @@ import io
 
 st.title("🕵️‍♀️ Object Detection")
 endpoint =os.getenv("MODEL_ENDPOINT", default = "http://0.0.0.0:8000")
+endpoint_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
 headers = {"accept": "application/json",
            "Content-Type": "application/json"}
+if endpoint_bearer:
+    headers["Authorization"] = f"Bearer {endpoint_bearer}"
 image = st.file_uploader("Upload Image")
 window = st.empty()
 

--- a/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
+++ b/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
@@ -12,6 +12,11 @@ import os
 model_service = os.getenv("MODEL_ENDPOINT",
                           "http://localhost:8001")
 model_service = f"{model_service}/v1"
+model_service_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
+request_kwargs = {}
+if model_service_bearer is not None:
+    request_kwargs = {"headers": {"Authorization": f"Bearer {model_service_bearer}"}}
+import pdb;pdb.set_trace()
 
 @st.cache_resource(show_spinner=False)
 def checking_model_service():
@@ -20,8 +25,8 @@ def checking_model_service():
     ready = False
     while not ready:
         try:
-            request_cpp = requests.get(f'{model_service}/models')
-            request_ollama = requests.get(f'{model_service[:-2]}api/tags')
+            request_cpp = requests.get(f'{model_service}/models', **request_kwargs)
+            request_ollama = requests.get(f'{model_service[:-2]}api/tags', **request_kwargs)
             if request_cpp.status_code == 200:
                 server = "Llamacpp_Python"
                 ready = True
@@ -37,7 +42,7 @@ def checking_model_service():
 
 def get_models():
     try:
-        response = requests.get(f"{model_service[:-2]}api/tags")
+        response = requests.get(f"{model_service[:-2]}api/tags", **request_kwargs)
         return [i["name"].split(":")[0] for i in  
             json.loads(response.content)["models"]]
     except:

--- a/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
+++ b/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
@@ -16,7 +16,6 @@ model_service_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
 request_kwargs = {}
 if model_service_bearer is not None:
     request_kwargs = {"headers": {"Authorization": f"Bearer {model_service_bearer}"}}
-import pdb;pdb.set_trace()
 
 @st.cache_resource(show_spinner=False)
 def checking_model_service():

--- a/recipes/natural_language_processing/codegen/app/codegen-app.py
+++ b/recipes/natural_language_processing/codegen/app/codegen-app.py
@@ -10,6 +10,10 @@ import time
 
 model_service = os.getenv("MODEL_ENDPOINT", "http://localhost:8001")
 model_service = f"{model_service}/v1"
+model_service_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
+request_kwargs = {}
+if model_service_bearer is not None:
+    request_kwargs = {"headers": {"Authorization": f"Bearer {model_service_bearer}"}}
 
 @st.cache_resource(show_spinner=False)
 def checking_model_service():
@@ -18,7 +22,7 @@ def checking_model_service():
     ready = False
     while not ready:
         try:
-            request = requests.get(f'{model_service}/models')
+            request = requests.get(f'{model_service}/models', **request_kwargs)
             if request.status_code == 200:
                 ready = True
         except:

--- a/recipes/natural_language_processing/rag/app/rag_app.py
+++ b/recipes/natural_language_processing/rag/app/rag_app.py
@@ -12,6 +12,7 @@ import os
 
 model_service = os.getenv("MODEL_ENDPOINT","http://0.0.0.0:8001")
 model_service = f"{model_service}/v1"
+model_service_bearer = os.getenv("MODEL_ENDPOINT_BEARER")
 model_name = os.getenv("MODEL_NAME", "") 
 chunk_size = os.getenv("CHUNK_SIZE", 150)
 embedding_model = os.getenv("EMBEDDING_MODEL","BAAI/bge-base-en-v1.5")
@@ -75,7 +76,7 @@ for msg in st.session_state.messages:
 
 
 llm = ChatOpenAI(base_url=model_service, 
-                 api_key="EMPTY",
+                 api_key="EMPTY" if model_service_bearer is None else model_service_bearer,
                  model=model_name,
                  streaming=True,
                  callbacks=[StreamlitCallbackHandler(st.container(),


### PR DESCRIPTION
## PR Description

The PR adds support to specific recipes for [Bearer Authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/). The affected recipes are:

* `audio/audio_to_text`
* `computer_vision/object_detection`
* `natural_language_processing/chatbot`
* `natural_language_processing/codegen`
* `natural_language_processing/rag`
* `natural_language_processing/summarizer`

In order to activate the bearer authentication support an env var called `MODEL_ENDPOINT_BEARER` should be provided. In case the env var is not provided the recipes work like before.

I've decided to open a PR following what is mentioned in the contributing guide [here](https://github.com/containers/ai-lab-recipes/blob/main/CONTRIBUTING.md#additional-contributions), let me know if I should do something else :)