### PR TITLE
AMD bootc - amdgpu kernel modules build process

### DIFF
--- a/training/amd-bootc/Containerfile
+++ b/training/amd-bootc/Containerfile
@@ -7,11 +7,17 @@ FROM ${DRIVER_TOOLKIT_IMAGE} AS builder
 COPY repos.d/amdgpu.repo /etc/yum.repos.d/amdgpu.repo
 COPY repos.d/RPM-GPG-KEY-AMD-ROCM /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM
 
+COPY scripts/amdgpu_download.sh /root/amdgpu_download.sh
+COPY scripts/amdgpu_build.sh /root/amdgpu_build.sh
+COPY scripts/amdgpu_package.sh /root/amdgpu_package.sh
+
 USER root
 
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AMD-ROCM \
-    && dnf install -y amdgpu-dkms \
-    && dnf clean all
+    && chmod +x /root/amdgpu_download.sh /root/amdgpu_build.sh /root/amdgpu_package.sh \
+    && /root/amdgpu_download.sh \
+    && /root/amdgpu_build.sh \
+    && /root/amdgpu_package.sh
 
 FROM ${BASEIMAGE}
 
@@ -20,11 +26,7 @@ LABEL vendor=${VENDOR}
 LABEL org.opencontainers.image.vendor=${VENDOR}
 
 RUN --mount=type=bind,from=builder,source=/,destination=/tmp/builder,ro \
-    export KERNEL_VERSION=$(rpm -q --qf '%{VERSION}-%{RELEASE}.%{ARCH}' kernel-core) \
-    && rm -f /lib/modules/${KERNEL_VERSION}/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko.xz \
-    && cp -r /tmp/builder/lib/modules/${KERNEL_VERSION}/extra /lib/modules/${KERNEL_VERSION}/extra \
-    && cp -r /tmp/builder/lib/firmware/updates/amdgpu /lib/firmware/amdgpu \
-    && depmod ${KERNEL_VERSION}
+    rpm -i /tmp/builder/root/rpmbuild/RPMS/x86_64/amdgpu-modules-*.rpm
 
 ARG EXTRA_RPM_PACKAGES=''
 

--- a/training/amd-bootc/scripts/amdgpu_build.sh
+++ b/training/amd-bootc/scripts/amdgpu_build.sh
@@ -1,0 +1,46 @@
+#!/bin/env bash
+
+BASE_PATH=/tmp/amdgpu-dkms
+AMDGPU_NAME=$(basename -- $BASE_PATH/usr/src/amdgpu-*) && \
+AMDGPU_TREE="$BASE_PATH/usr/src/$AMDGPU_NAME" && \
+SRC_TREE=$(ls -d /usr/src/kernels/*) && \
+
+
+export CONFIG_DRM=m && \
+export CONFIG_KALLSYMS=y && \
+export CONFIG_HSA_AMD=y && \
+export CONFIG_DRM_TTM=m && \
+export CONFIG_DRM_TTM_DMA_PAGE_POOL=y && \
+export CONFIG_DRM_AMDGPU=m && \
+export CONFIG_DRM_SCHED=m && \
+export CONFIG_DRM_AMDGPU_CIK=y && \
+export CONFIG_DRM_AMDGPU_SI=y && \
+export CONFIG_DRM_AMDGPU_USERPTR=y && \
+export CONFIG_DRM_AMD_DC=y && \
+
+cd "$AMDGPU_TREE/amd/dkms" && ./configure && \
+
+cd "$AMDGPU_TREE" && \
+source "$AMDGPU_TREE/amd/amdkcl/files" && \
+for file in $FILES; do
+    awk -F'[()]' '/EXPORT_SYMBOL/ {
+        print "#define "$2" amd"$2" //"$0
+    }' "$file" | sort -u >> "$AMDGPU_TREE/include/rename_symbol.h"
+done && \
+
+DRM_VER=$(sed -n 's/^RHEL_DRM_VERSION = \(.*\)/\1/p' "$SRC_TREE/Makefile") && \
+DRM_PATCH=$(sed -n 's/^RHEL_DRM_PATCHLEVEL = \(.*\)/\1/p' "$SRC_TREE/Makefile") && \
+DRM_SUB="0" && \
+
+EXTRA_CFLAGS="-I$AMDGPU_TREE/include " && \
+EXTRA_CFLAGS+="-I$AMDGPU_TREE/include/uapi " && \
+EXTRA_CFLAGS+="-I$AMDGPU_TREE/include/kcl/header " && \
+EXTRA_CFLAGS+="-DDRM_VER=$DRM_VER " && \
+EXTRA_CFLAGS+="-DDRM_PATCH=$DRM_PATCH " && \
+EXTRA_CFLAGS+="-DDRM_SUB=$DRM_SUB " && \
+EXTRA_CFLAGS+="-include kcl/kcl_version.h " && \
+EXTRA_CFLAGS+="-include rename_symbol.h " && \
+EXTRA_CFLAGS+="-include $AMDGPU_TREE/amd/dkms/config/config.h " && \
+
+cd "$SRC_TREE" && \
+make M="$AMDGPU_TREE" EXTRA_CFLAGS="$EXTRA_CFLAGS" -j"$(nproc)" SCHED_NAME="amd-sched" TTM_NAME="amdttm"

--- a/training/amd-bootc/scripts/amdgpu_download.sh
+++ b/training/amd-bootc/scripts/amdgpu_download.sh
@@ -1,0 +1,10 @@
+#!/bin/env bash
+BASE_PATH=/tmp/amdgpu-dkms
+
+rm -rf $BASE_PATH && \
+mkdir $BASE_PATH && \
+cd $BASE_PATH && \
+
+dnf download amdgpu-dkms && \
+
+rpm2cpio amdgpu-dkms-*.el9.noarch.rpm | cpio -idmv

--- a/training/amd-bootc/scripts/amdgpu_package.sh
+++ b/training/amd-bootc/scripts/amdgpu_package.sh
@@ -1,0 +1,53 @@
+#!/bin/env bash
+
+BASE_PATH=/tmp/amdgpu-dkms
+AMDGPU_NAME=$(basename -- $BASE_PATH/usr/src/amdgpu-*) && \
+AMDGPU_TREE="$BASE_PATH/usr/src/$AMDGPU_NAME" && \
+KERNEL_SVER=$(rpm -q --qf '%{VERSION}-%{RELEASE}' kernel) && \
+KERNEL_VERSION=$(rpm -q --qf '%{VERSION}-%{RELEASE}.%{ARCH}' kernel) && \
+SRC_TREE="/usr/src/kernels/$KERNEL_VERSION" && \
+DRIVER_VERSION=$(rpm -qp --queryformat '%{VERSION}' $BASE_PATH/amdgpu-dkms-*.el9.noarch.rpm) && \
+
+mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS} && \
+
+mkdir "/root/rpmbuild/SOURCES/amdgpu-modules-$KERNEL_VERSION" && \
+
+cp -r "$BASE_PATH/etc" "/root/rpmbuild/SOURCES/amdgpu-modules-$KERNEL_VERSION/" && \
+
+make -C "$SRC_TREE" M="$AMDGPU_TREE" modules_install INSTALL_MOD_PATH="/root/rpmbuild/SOURCES/amdgpu-modules-$KERNEL_VERSION" DEPMOD=/bin/true && \
+
+cd /root/rpmbuild/SOURCES && \
+tar czvf amdgpu-modules.tar.gz "amdgpu-modules-$KERNEL_VERSION" && \
+
+SPEC_FILE="/root/rpmbuild/SPECS/amdgpu-modules.spec"
+cat <<EOF > "$SPEC_FILE"
+Name: amdgpu-modules
+Version: $DRIVER_VERSION
+Release: 1
+Summary: AMDGPU drivers
+License: Proprietary
+Group: System Environment/Kernel
+BuildArch: $(uname -m)
+Requires: kernel = $KERNEL_SVER
+Source0: amdgpu-modules.tar.gz
+
+%description
+This package contains AMDGPU out-of-tree kernel modules for kernel version $KERNEL_VERSION.
+
+%prep
+%setup -q -n amdgpu-modules-$KERNEL_VERSION
+
+%install
+mkdir -p %{buildroot}/lib/modules/$KERNEL_VERSION
+cp -r lib/modules/$KERNEL_VERSION/* %{buildroot}/lib/modules/$KERNEL_VERSION/
+
+%post
+/sbin/depmod -a $KERNEL_VERSION
+
+%files
+/lib/modules/$KERNEL_VERSION
+
+EOF
+
+# Build the RPM
+rpmbuild -bb "$SPEC_FILE"


### PR DESCRIPTION
This PR implements a custom build process for out-of-tree amdgpu modules, instead of using dkms.

- The same version of the out-of-tree source code is downloaded, and a script is executed to build the modules.
- After the kernel modules are built, they are packaged into an RPM and installed in the final amd-bootc image as a package.

