### PR TITLE
Pass bearer to ChatOpenAI object

### DIFF
--- a/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
+++ b/recipes/natural_language_processing/chatbot/app/chatbot_ui.py
@@ -80,7 +80,7 @@ if server == "Ollama":
             options=models)
 
 llm = ChatOpenAI(base_url=model_service, 
-        api_key="sk-no-key-required",
+        api_key="sk-no-key-required" if model_service_bearer is None else model_service_bearer,
         model=model_name,
         streaming=True,
         callbacks=[StreamlitCallbackHandler(st.empty(),

--- a/recipes/natural_language_processing/codegen/app/codegen-app.py
+++ b/recipes/natural_language_processing/codegen/app/codegen-app.py
@@ -47,7 +47,7 @@ model_name = os.getenv("MODEL_NAME", "")
 
 llm = ChatOpenAI(base_url=model_service,
                  model=model_name,
-                 api_key="EMPTY",
+                 api_key="EMPTY" if model_service_bearer is None else model_service_bearer,
                  streaming=True)
 
 # Define the Langchain chain


### PR DESCRIPTION
# PR Description

Simply passes the bearer to `ChatOpenAI` object too for `codegen` and `chatbot` recipes.

Is an additional PR based on https://github.com/containers/ai-lab-recipes/pull/790 where the bearer auth support was added.