### PR TITLE
Disable google-cloud-ops-agent

### DIFF
--- a/training/cloud/gcp/cloud-setup.sh
+++ b/training/cloud/gcp/cloud-setup.sh
@@ -27,10 +27,13 @@ dnf install -y --nobest \
     vim
 mv /etc/selinux.tmp /etc/selinux
 
-# Install Google Ops Agent
-curl -sSo /tmp/add-google-cloud-ops-agent-repo.sh https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
-bash /tmp/add-google-cloud-ops-agent-repo.sh --also-install --remove-repo
-rm /tmp/add-google-cloud-ops-agent-repo.sh
+# The current version of google-cloud-ops-agent is impacted by a CVE: https://access.redhat.com/security/cve/CVE-2024-41110
+# It will be disable for the meantime
+#
+# # Install Google Ops Agent
+# curl -sSo /tmp/add-google-cloud-ops-agent-repo.sh https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+# bash /tmp/add-google-cloud-ops-agent-repo.sh --also-install --remove-repo
+# rm /tmp/add-google-cloud-ops-agent-repo.sh
 
 # rpm-state is needed to remove microcode_ctl
 mkdir /var/lib/rpm-state


### PR DESCRIPTION
The current version of google-cloud-ops-agent is impacted by a CVE: https://access.redhat.com/security/cve/CVE-2024-41110