### PR TITLE
Use cloud-user as a default username in AWS

### DIFF
--- a/training/cloud/aws/README.md
+++ b/training/cloud/aws/README.md
@@ -20,8 +20,6 @@ console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
 - Getty configuration
     - NautoVTs false
 
-- Cloud init default user: `ec2-user`
-
 - Packages
     - @core metapackage
     - authselect-compat

--- a/training/cloud/aws/files/etc/cloud/cloud.cfg.d/00-rhel-default-user.cfg
+++ b/training/cloud/aws/files/etc/cloud/cloud.cfg.d/00-rhel-default-user.cfg
@@ -1,3 +1,0 @@
-system_info:
-  default_user:
-    name: ec2-user


### PR DESCRIPTION
The documentation reflects the user `cloud-user` so we want to keep it that way