### PR TITLE
cloud gcp mkdir handle existing directory

### DIFF
--- a/training/cloud/gcp/cloud-setup.sh
+++ b/training/cloud/gcp/cloud-setup.sh
@@ -36,11 +36,10 @@ mv /etc/selinux.tmp /etc/selinux
 # rm /tmp/add-google-cloud-ops-agent-repo.sh
 
 # rpm-state is needed to remove microcode_ctl
-mkdir /var/lib/rpm-state
+mkdir -p /var/lib/rpm-state
 dnf remove -y \
     irqbalance \
     microcode_ctl
-rmdir /var/lib/rpm-state
 
 rm -f /etc/yum.repos.d/google-cloud.repo
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/RHELAI-3200

this merge request is failing: https://gitlab.com/redhat/rhel-ai/containers/nvidia-gcp-bootc/-/merge_requests/58

error log:
```
mkdir: cannot create directory '/var/lib/rpm-state': File exists
```

is there any concern that this directory exists? since we're deleting it a couple of lines below.