### PR TITLE
[WIP] Fix convert_models build and run issues

### DIFF
--- a/convert_models/Containerfile
+++ b/convert_models/Containerfile
@@ -7,4 +7,7 @@ RUN git clone https://github.com/ggerganov/llama.cpp.git
 RUN cd llama.cpp/ && cmake -B build && cmake --build build --config Release
 RUN pip install -r llama.cpp/requirements.txt
 COPY . /opt/app-root/src/converter/
+USER root
+RUN chmod -R ug=rwX,o-rwx /opt/app-root/src/converter
+USER default
 ENTRYPOINT ["sh", "run.sh"]

--- a/convert_models/Containerfile
+++ b/convert_models/Containerfile
@@ -4,7 +4,7 @@ USER root
 RUN chown -R default:root /opt/app-root/src/converter
 USER default
 RUN git clone https://github.com/ggerganov/llama.cpp.git
-RUN cd llama.cpp/ && make
+RUN cd llama.cpp/ && cmake -B build && cmake --build build --config Release
 RUN pip install -r llama.cpp/requirements.txt
 COPY . /opt/app-root/src/converter/
 ENTRYPOINT ["sh", "run.sh"]

--- a/convert_models/download_huggingface.py
+++ b/convert_models/download_huggingface.py
@@ -9,5 +9,4 @@ args = parser.parse_args()
 snapshot_download(repo_id=args.model,
                 token=args.token,
                 local_dir=f"converted_models/{args.model}",
-                local_dir_use_symlinks=True,
                 cache_dir=f"converted_models/cache")

--- a/convert_models/run.sh
+++ b/convert_models/run.sh
@@ -20,13 +20,13 @@ python download_huggingface.py --model $hf_model_url --token $hf_token
 python llama.cpp/examples/convert_legacy_llama.py /opt/app-root/src/converter/converted_models/$hf_model_url
 python llama.cpp/convert_hf_to_gguf.py /opt/app-root/src/converter/converted_models/$hf_model_url
 mkdir -p /opt/app-root/src/converter/converted_models/gguf/
-llama.cpp/llama-quantize /opt/app-root/src/converter/converted_models/$hf_model_url/ggml-model-f16.gguf /opt/app-root/src/converter/converted_models/gguf/$model_org-$model_name-${QUANTIZATION}.gguf ${QUANTIZATION}
+llama.cpp/build/bin/llama-quantize /opt/app-root/src/converter/converted_models/$hf_model_url/ggml-model-f16.gguf /opt/app-root/src/converter/converted_models/gguf/$model_org-$model_name-${QUANTIZATION}.gguf ${QUANTIZATION}
 rm -rf /opt/app-root/src/converter/converted_models/$model_org
 
 if [ $keep_orgi = "False" ]; then
     rm -rf /opt/app-root/src/converter/converted_models/cache
 fi
 
-echo "Converted and quantized model written to /opt/app-root/src/converter/converted_models/gguf/$model_org-$model_name.gguf" 
+echo "Converted and quantized model written to /opt/app-root/src/converter/converted_models/gguf/$model_org-$model_name.gguf"
 echo "$ ls /opt/app-root/src/converter/converted_models/gguf/"
 ls /opt/app-root/src/converter/converted_models/gguf/


### PR DESCRIPTION
Status:

Fixing issues and errors as I come across them. Still working towards it converting a model.

Fixes:

```
STEP 7/10: RUN cd llama.cpp/ && make
Makefile:2: *** The Makefile build is deprecated. Use the CMake build instead. For more details, see https://github.com/ggerganov/llama.cpp/blob/master/docs/build.md.  Stop.
Error: building at STEP "RUN cd llama.cpp/ && make": while running runtime: exit status 2
```

```
UserWarning: `local_dir_use_symlinks` parameter is deprecated and will be ignored. The process to download files to a local folder has been updated and do
 not rely on symlinks anymore. You only need to pass a destination folder as`local_dir`.
```

And also permission denied errors when you have a restrictive umask on the build system.